### PR TITLE
Add `helpers.py` definitions in TLA+

### DIFF
--- a/spec/helpers.tla
+++ b/spec/helpers.tla
@@ -1,6 +1,6 @@
 ---- MODULE helpers ----
 
-EXTENDS typedefs, Apalache, Integers
+EXTENDS typedefs, Apalache, Integers, Tuples
 
 CONSTANTS
     (*
@@ -148,9 +148,9 @@ get_blockchain(block, node_state) ==
             last_block_and_chain_upto_slot
         ELSE
             LET parent == get_parent(last_block, node_state) IN
-            << parent, Push(chain_upto_slot, parent) >>
+            Pair(parent, Push(chain_upto_slot, parent))
     IN
-    ApaFoldSet( ChainWithParent, <<block, List(<< block >>)>>, ApalacheFoldSlots(node_state) )[2]
+    ApaFoldSet( ChainWithParent, Pair(block, List(<< block >>)), ApalacheFoldSlots(node_state) )[2]
 
 \* @type: ($block, $commonNodeState) => Bool;
 is_complete_chain(block, node_state) ==
@@ -185,11 +185,11 @@ is_ancestor_descendant_relationship(ancestor, descendant, node_state) ==
     FindAncestor(last_block_and_flag, slot) ==
         LET last_block == last_block_and_flag[1] IN
         LET flag == last_block_and_flag[2] IN
-        IF last_block = ancestor \/ flag THEN << last_block, TRUE >>
-        ELSE IF last_block = node_state.configuration.genesis \/ ~has_parent(last_block, node_state) THEN << last_block, FALSE >>
-        ELSE << get_parent(last_block, node_state), FALSE >>
+        IF last_block = ancestor \/ flag THEN Pair(last_block, TRUE)
+        ELSE IF last_block = node_state.configuration.genesis \/ ~has_parent(last_block, node_state) THEN Pair(last_block, FALSE)
+        ELSE Pair(get_parent(last_block, node_state), FALSE)
     IN
-    ApaFoldSet( FindAncestor, << descendant, FALSE >>, ApalacheFoldSlots(node_state) )[2]
+    ApaFoldSet( FindAncestor, Pair(descendant, FALSE), ApalacheFoldSlots(node_state) )[2]
 
 (*
  * Filter blocks, retaining only those that are ancestors of a specified block.
@@ -228,9 +228,9 @@ have_common_ancestor(chain1, chain2, node_state) ==
                 last_block_and_chain_upto_slot
             ELSE
                 LET parent == get_parent(last_block, node_state) IN
-                << parent, chain_upto_slot \union { parent } >>
+                Pair(parent, chain_upto_slot \union { parent })
         IN
-        ApaFoldSet( ChainWithParent, <<block, { block } >>, ApalacheFoldSlots(node_state) )[2]
+        ApaFoldSet( ChainWithParent, Pair(block, { block }), ApalacheFoldSlots(node_state) )[2]
     IN
     get_blockchain_set(chain1) \intersect get_blockchain_set(chain2) # {}
 


### PR DESCRIPTION
Add the definitions from [`helpers.py`](https://github.com/saltiniroberto/ssf/blob/7ea6e18093d9da3154b4e396dd435549f687e6b9/high_level/common/helpers.py) in TLA+.

All operators are more or less a verbatim translation following [`Translation.md`](https://github.com/freespek/ssf-mc/blob/98f63c376b27e2a7aeb6bb19bdd6f9bb6986da4a/Translation.md)

For recursive operators, we introduce a naive recursive translation (with prefix `TLC_`), and a fold-based translation for Apalache. The non-recursive versions are obviously more free-form and probably deserve additional scrutiny.

@Kukovec @konnov for review