### PR TITLE
Extended spec with `get_greatest_finalized_checkpoint` and its dependencies

### DIFF
--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -15,6 +15,10 @@ BLOCK_HASH(b) == b.body
 VERIFY_VOTE_SIGNATURE(vote) == TRUE
 
 
+\* Stake associated with each validator in a given slot.
+\*
+\* Assume uniform voting power for model checking.
+\*
 \* @type: ($block, Int, $commonNodeState) => $validatorBalances;
 GET_VALIDATOR_SET_FOR_SLOT(block, slot, node_state) == [node \in Nodes |-> 100]
 

--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -1,5 +1,8 @@
 ----------------------------- MODULE MC_ffg -----------------------------
 
+Nodes == { "A", "B", "C", "D", "E", "F", "G"}
+MAX_SLOT == 5
+
 \* ========== Dummy implementations of stubs ==========
 
 \* SRC: https://github.com/saltiniroberto/ssf/blob/7ea6e18093d9da3154b4e396dd435549f687e6b9/high_level/common/stubs.pyi#L6
@@ -11,15 +14,17 @@ BLOCK_HASH(b) == b.body
 \* @type: ($signedVoteMessage) => Bool;
 VERIFY_VOTE_SIGNATURE(vote) == TRUE
 
-\* ====================================================
 
-Nodes == { "A", "B", "C", "D", "E", "F", "G"}
-MAX_SLOT == 5
+\* @type: ($block, Int, $commonNodeState) => $validatorBalances;
+GET_VALIDATOR_SET_FOR_SLOT(block, slot, node_state) == [node \in Nodes |-> 100]
+
+\* ====================================================
 
 INSTANCE ffg WITH
     BLOCK_HASH <- BLOCK_HASH,
     VERIFY_VOTE_SIGNATURE <- VERIFY_VOTE_SIGNATURE,
-    MAX_SLOT <- MAX_SLOT
+    MAX_SLOT <- MAX_SLOT,
+    GET_VALIDATOR_SET_FOR_SLOT <- GET_VALIDATOR_SET_FOR_SLOT
 
 VARIABLES
     \* @type: $commonNodeState;
@@ -66,8 +71,12 @@ IsValidBlock(block, node_state) ==
     /\ block.slot >= 0
     /\ block.slot <= MAX_SLOT
     /\ \A voteMsg \in block.votes: IsValidSigedVoteMessage(voteMsg, node_state)
-    \* The set of messages increases monotonically
-    /\ get_block_from_hash(block.parent_hash, node_state).votes \subseteq block.votes
+    /\  LET parent == get_block_from_hash(block.parent_hash, node_state)
+        IN
+        \* Parent has lower slot #
+        /\ parent.slot < block.slot
+        \* The set of messages increases monotonically
+        /\ parent.votes \subseteq block.votes
 
 \* @type: ($proposeMessage, $commonNodeState) => Bool;
 IsValidProposeMessage(msg, node_state) ==
@@ -92,7 +101,7 @@ GenesisBlock == [
 IsValidConfiguration(cfg, node_state) ==
     /\ cfg.delta >= 0
     /\ cfg.genesis = GenesisBlock
-    /\ cfg.eta >= 0
+    /\ cfg.eta >= 1
     /\ cfg.k >= 0
 
 \* @type: ($commonNodeState) => Bool;
@@ -119,6 +128,10 @@ Init ==
 Next == UNCHANGED single_node_state
 
 NoSlashableInv == get_slashable_nodes(single_node_state.view_votes) = {}
+
+EbbAndFLowInv == 
+    LET lastFinBLock == get_block_from_hash(get_greatest_finalized_checkpoint(single_node_state).block_hash, single_node_state)
+    IN is_ancestor_descendant_relationship(lastFinBLock, single_node_state.chava)
 
 Inv == NoSlashableInv
 

--- a/spec/ffg.tla
+++ b/spec/ffg.tla
@@ -8,7 +8,15 @@ CONSTANTS
      *
      * @type: ($signedVoteMessage) => Bool;
      *)
-    VERIFY_VOTE_SIGNATURE(_)
+    VERIFY_VOTE_SIGNATURE(_),
+
+    (*
+     * TODO
+     *
+     * Requires(is_complete_chain(block, nodeState))
+     * @type: ($block, Int, $commonNodeState) => $validatorBalances;
+     *)
+    GET_VALIDATOR_SET_FOR_SLOT(_,_,_)
 
 \* ========  HELPER METHODS ========
 
@@ -86,5 +94,203 @@ get_slashable_nodes_unoptimized(vote_view) ==
             IN ~(S = {})
         IN { vote \in vote_view: lambda1(vote)}
     IN { vote.sender : vote \in filtered}
+
+\* ================================
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L20
+\* A FFG vote is valid if:
+\*     - the sender is a validator;
+\*     - `vote.message.ffg_source.block_hash` is an ancestor of `vote.message.ffg_target.block_hash`;
+\*     - the checkpoint slot of `vote.message.ffg_source` is strictly less than checkpoint slot of `vote.message.ffg_target`;
+\*     - the block associated with `vote.message.ffg_source.block_hash` has a slot number that matches the slot number specified in the same vote message;
+\*     - the block associated with `vote.message.ffg_target.block_hash` has a slot number that matches the slot number specified in the same vote message;
+\*     - the block hash associated the source exists within a validator's view of blocks; and
+\*     - the block hash associated the target exists within a validator's view of blocks.
+\* @type: ($signedVoteMessage, $commonNodeState) => Bool;
+valid_FFG_vote(vote, node_state) ==
+    /\ VERIFY_VOTE_SIGNATURE(vote)
+    /\ is_validator(
+            vote.sender,
+            GET_VALIDATOR_SET_FOR_SLOT(
+                get_block_from_hash(vote.message.head_hash, node_state), 
+                vote.message.slot, 
+                node_state
+            )
+        )
+    /\ is_ancestor_descendant_relationship(
+            get_block_from_hash(vote.message.ffg_source.block_hash, node_state),
+            get_block_from_hash(vote.message.ffg_target.block_hash, node_state),
+            node_state
+        )
+    /\ vote.message.ffg_source.chkp_slot < vote.message.ffg_target.chkp_slot
+    /\ has_block_hash(vote.message.ffg_source.block_hash, node_state)
+    /\ get_block_from_hash(vote.message.ffg_source.block_hash, node_state).slot = vote.message.ffg_source.block_slot
+    /\ has_block_hash(vote.message.ffg_target.block_hash, node_state)
+    /\ get_block_from_hash(vote.message.ffg_target.block_hash, node_state).slot = vote.message.ffg_target.block_slot
+
+\* @type: ($checkpoint, $commonNodeState) => Bool;
+RECURSIVE is_justified_checkpoint(_, _)
+
+\* Apalache refuses to typecheck mutually-recursive operators, so we invent an operator with the same
+\* signature as is_justified_checkpoint for typechecking is_FFG_vote_in_support_of_checkpoint_justification
+\* @type: ($checkpoint, $commonNodeState) => Bool;
+tc_dummy(a,b) == TRUE
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L48
+\* It determines whether a given `vote` supports the justification of a specified `checkpoint`.
+RECURSIVE is_FFG_vote_in_support_of_checkpoint_justification(_, _, _)
+\* @type: ($signedVoteMessage, $checkpoint, $commonNodeState) => Bool;
+is_FFG_vote_in_support_of_checkpoint_justification(vote, checkpoint, node_state) ==
+    /\ valid_FFG_vote(vote, node_state)
+    /\ vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot
+    /\ is_ancestor_descendant_relationship(
+            get_block_from_hash(checkpoint.block_hash, node_state),
+            get_block_from_hash(vote.message.ffg_target.block_hash, node_state),
+            node_state
+        )
+    /\ is_ancestor_descendant_relationship(
+            get_block_from_hash(vote.message.ffg_source.block_hash, node_state),
+            get_block_from_hash(checkpoint.block_hash, node_state),
+            node_state)
+    \* /\ is_justified_checkpoint(vote.message.ffg_source, node_state) 
+    /\ tc_dummy(vote.message.ffg_source, node_state) 
+    
+
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L67
+\* It filters out ffg votes that do not support the justification of a specified `checkpoint`.
+RECURSIVE filter_out_FFG_votes_not_in_FFG_support_of_checkpoint_justification(_, _, _)
+\* @type: (Set($signedVoteMessage), $checkpoint, $commonNodeState) => Set($signedVoteMessage);
+filter_out_FFG_votes_not_in_FFG_support_of_checkpoint_justification(votes, checkpoint, node_state) ==
+    {vote \in votes: is_FFG_vote_in_support_of_checkpoint_justification(vote, checkpoint, node_state)}
+    
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L74
+\* It identifies and returns the set of validators that have cast `votes` in support of the justification of a specified `checkpoint`.
+RECURSIVE get_validators_in_FFG_support_of_checkpoint_justification(_, _, _)
+\* @type: (Set($signedVoteMessage), $checkpoint, $commonNodeState) => Set($nodeIdentity);
+get_validators_in_FFG_support_of_checkpoint_justification(votes, checkpoint, node_state) ==
+    {vote.sender : vote \in filter_out_FFG_votes_not_in_FFG_support_of_checkpoint_justification(votes, checkpoint, node_state)}
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L84
+\* It checks whether a `checkpoint` if justified, specifically a `checkpoint` is justified if at least
+\* two-thirds of the total validator set weight is in support. This is evaluated by checking if
+\* `FFG_support_weight * 3 >= tot_validator_set_weight * 2`.
+\* @type: ($checkpoint, $commonNodeState) => Bool;
+is_justified_checkpoint(checkpoint, node_state) ==
+    IF checkpoint = genesis_checkpoint(node_state)
+    THEN TRUE
+    ELSE 
+        LET
+            hasBlockHash == has_block_hash(checkpoint.block_hash, node_state)
+            isCompleteChain == 
+                is_complete_chain(
+                    get_block_from_hash(checkpoint.block_hash, node_state), 
+                    node_state
+                )
+        IN 
+            IF (~hasBlockHash \/ ~isCompleteChain)
+            THEN FALSE
+            ELSE
+                LET 
+                    validatorBalances == 
+                        GET_VALIDATOR_SET_FOR_SLOT(
+                            get_block_from_hash(checkpoint.block_hash, node_state), 
+                            checkpoint.block_slot, 
+                            node_state
+                        )
+                IN LET 
+                    FFG_support_weight == 
+                        validator_set_weight(
+                            get_validators_in_FFG_support_of_checkpoint_justification(
+                                node_state.view_votes, 
+                                checkpoint, 
+                                node_state
+                            ), 
+                            validatorBalances
+                        )
+                    tot_validator_set_weight == 
+                        validator_set_weight(DOMAIN validatorBalances, validatorBalances)
+                IN FFG_support_weight * 3 >= tot_validator_set_weight * 2
+
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L134
+\* It evaluates whether a given `vote` represents a link from a specified `checkpoint` to a checkpoint in the immediately following slot.
+\* @type: ($signedVoteMessage, $checkpoint, $commonNodeState) => Bool;
+is_FFG_vote_linking_to_a_checkpoint_in_next_slot(vote, checkpoint, node_state) ==
+    /\ valid_FFG_vote(vote, node_state)
+    /\ vote.message.ffg_source = checkpoint
+    /\ vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot + 1
+
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L145
+\* It filters and retains only those votes from a `node_state` that are linking to a `checkpoint` in the next slot.
+\* @type: ($checkpoint, $commonNodeState) => Set($signedVoteMessage);
+filter_out_FFG_vote_not_linking_to_a_checkpoint_in_next_slot(checkpoint, node_state) ==
+    { vote \in node_state.view_votes : is_FFG_vote_linking_to_a_checkpoint_in_next_slot(vote, checkpoint, node_state)}
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L152
+\* It retrieves the identities of validators who have cast ffg votes that support linking a specified `checkpoint` to its immediate successor.
+\* @type: ($checkpoint, $commonNodeState) => Set($nodeIdentity);
+get_validators_in_FFG_votes_linking_to_a_checkpoint_in_next_slot(checkpoint, node_state) == 
+    {vote.sender : vote \in filter_out_FFG_vote_not_linking_to_a_checkpoint_in_next_slot(checkpoint, node_state)}
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L162
+\* It evaluates whether a given `checkpoint` has been finalized. A `checkpoint` is considered finalized if it is justified and
+\* if at least two-thirds of the total validator set's weight supports the transition from this `checkpoint` to the next. Specifically, it first checks if the `checkpoint` is justified using
+\* `is_justified_checkpoint(checkpoint, node_state)`. Then it retrieves the set of validators and their balances for the slot associated with the `checkpoint`.
+\* This is done through `get_validator_set_for_slot`. Then it calculates the total weight (stake) of validators who have cast votes
+\* linking the `checkpoint` to the next slot, using `get_validators_in_FFG_votes_linking_to_a_checkpoint_in_next_slot` to identify these validators
+\* and `validator_set_weight` to sum their stakes. Finally it checks if `FFG_support_weight * 3 >= tot_validator_set_weight * 2` to finalize `checkpoint`.
+\* @type: ($checkpoint, $commonNodeState) => Bool;
+is_finalized_checkpoint(checkpoint, node_state) ==
+    IF ~is_justified_checkpoint(checkpoint, node_state)
+    THEN FALSE
+    ELSE 
+        LET 
+            validatorBalances == 
+                GET_VALIDATOR_SET_FOR_SLOT(
+                    get_block_from_hash(checkpoint.block_hash, node_state), 
+                    checkpoint.block_slot, 
+                    node_state
+                )
+        IN LET
+            FFG_support_weight == 
+                validator_set_weight(
+                    get_validators_in_FFG_votes_linking_to_a_checkpoint_in_next_slot(checkpoint, node_state), 
+                    validatorBalances
+                )
+            tot_validator_set_weight == 
+                validator_set_weight(DOMAIN validatorBalances, validatorBalances)
+        IN FFG_support_weight * 3 >= tot_validator_set_weight * 2
+        
+    
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L181
+\* @type: (Set($checkpoint), $commonNodeState) => Set($checkpoint);
+filter_out_non_finalized_checkpoint(checkpoints, node_state) ==
+    {checkpoint \in checkpoints: is_finalized_checkpoint(checkpoint, node_state)}
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/7ea6e18093d9da3154b4e396dd435549f687e6b9/high_level/common/ffg.py#L10
+\* It extracts a set of ffg targets from a set of `votes`.
+\* @type: (Set($signedVoteMessage)) => Set($checkpoint);
+get_set_FFG_targets(votes) ==
+    { vote.message.ffg_target: vote \in votes }
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/7ea6e18093d9da3154b4e396dd435549f687e6b9/high_level/common/ffg.py#L188
+\* It retrieves from `node_state` all the checkpoints that have been finalized.
+\* @type: ($commonNodeState) => Set($checkpoint); 
+get_finalized_checkpoints(node_state) ==
+    LET ffgTargets == get_set_FFG_targets(node_state.view_votes)
+    IN LET filtered == filter_out_non_finalized_checkpoint(ffgTargets, node_state)
+    IN filtered \cup {genesis_checkpoint(node_state)}
+
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/7ea6e18093d9da3154b4e396dd435549f687e6b9/high_level/common/ffg.py#L198
+\* It returns the greatest finalized checkpoint from a `node_state`.
+\* @type: ($commonNodeState) => $checkpoint;
+get_greatest_finalized_checkpoint(node_state) == 
+    LET e == get_finalized_checkpoints(node_state)
+    IN CHOOSE max \in e: \A x \in e: (x.chkp_slot <= max.chkp_slot)
+
 
 =============================================================================

--- a/spec/ffg.tla
+++ b/spec/ffg.tla
@@ -282,15 +282,15 @@ get_set_FFG_targets(votes) ==
 get_finalized_checkpoints(node_state) ==
     LET ffgTargets == get_set_FFG_targets(node_state.view_votes)
     IN LET filtered == filter_out_non_finalized_checkpoint(ffgTargets, node_state)
-    IN filtered \cup {genesis_checkpoint(node_state)}
+    IN filtered \union {genesis_checkpoint(node_state)}
 
 
 \* SRC: https://github.com/saltiniroberto/ssf/blob/7ea6e18093d9da3154b4e396dd435549f687e6b9/high_level/common/ffg.py#L198
 \* It returns the greatest finalized checkpoint from a `node_state`.
 \* @type: ($commonNodeState) => $checkpoint;
 get_greatest_finalized_checkpoint(node_state) == 
-    LET e == get_finalized_checkpoints(node_state)
-    IN CHOOSE max \in e: \A x \in e: (x.chkp_slot <= max.chkp_slot)
+    LET finCheckpoints == get_finalized_checkpoints(node_state)
+    IN CHOOSE maxFinCheckpoint \in finCheckpoints: \A finCheckpoint \in finCheckpoints: (finCheckpoint.chkp_slot <= maxFinCheckpoint.chkp_slot)
 
 
 =============================================================================

--- a/spec/helpers.tla
+++ b/spec/helpers.tla
@@ -98,9 +98,10 @@ is_validator(node, validatorBalances) ==
  *)
 validator_set_weight(validators, validatorBalances) ==
     LET queried_validator_ids == validators \intersect (DOMAIN validatorBalances) IN
-    \* TODO(#7): Clarify: the following drops weights that occur multiple times
-    LET queried_validator_balances == { validatorBalances[v] : v \in queried_validator_ids } IN
-    ApaFoldSet(+, 0, queried_validator_balances)
+    LET 
+        \* @type: (Int, $nodeIdentity) => Int;
+        Accumulate(x, n) == x + validatorBalances[n]
+    IN ApaFoldSet(Accumulate, 0, queried_validator_ids)
 
 (*
  * Construct a blockchain from a given block back to the genesis block.


### PR DESCRIPTION
This PR introduces the following
  - Minor tweaks to the `MC_` validity properties
  - Ebb-and-flow invariant
  - A fix to the `helpers` method, implementing the corrected accumulation (the [issue](https://github.com/saltiniroberto/ssf/issues/3) has been fixed)
  - An specification following the call-tree of `get_greatest_finalized_checkpoint`
    - Since `is_justified_checkpoint` exhibits mutual recursion, not currently supported by the Apalache typechecker, the definition of `is_FFG_vote_in_support_of_checkpoint_justification` references `tc_dummy`, a method with the same signature as `is_justified_checkpoint`, to be able to typecheck. For model-checking with TLC, swap lines 155 and 156 in `ffg.tla`