### PR TITLE
Remove TODO for #7

### DIFF
--- a/spec/typedefs.tla
+++ b/spec/typedefs.tla
@@ -30,7 +30,6 @@ EXTENDS Lists
         votes: Set($signedVoteMessage),
         body: $blockBody
     };
-    TODO(#7): should this just be a `Set($signedVoteMessage)`?
     @typeAlias: listOfSignedVoteMessage = { es: Seq($signedVoteMessage) };
     @typeAlias: proposeMessage = {
         block: $block,


### PR DESCRIPTION
Remove an outstanding clarification comment in the spec.

@saltiniroberto confirmed on TG it's better to keep this as vector for long-term use cases.

Together with #13, closes #7