### PR TITLE
Nonrecursive implementation of `is_justified_checkpoint`

### DIFF
--- a/Translation.md
+++ b/Translation.md
@@ -383,7 +383,7 @@ In order to facilitate translation to the TLA+ fragment supported by Apalache, w
 Assume we are given a `RECURSIVE` operator `Op`. W.l.o.g. we can take the arity to be `1`, since any operator of higher arity can be expressed as an arity `1` operator over tuples or records.
 ```tla
 RECURSIVE Op(_)
-\* @type (a) => a;
+\* @type (a) => b;
 Op(x) ==
   IF P(x)
   THEN e
@@ -414,7 +414,7 @@ We can see that `Chain(x,N)` returns the sequence `<<v_n, ..., x>>` if `N` is su
 Using `Chain` we can define a fold-based non-recursive operator `Op^`, such that `Op^(x) = Op(x)` under the above assumptions:
 
 ```tla
-\* @type (a, Int) => a;
+\* @type (a, Int) => b;
 NonrecursiveOp(x, N) ==
 LET chain == Chain(x, N) IN
 LET step(cumul, v) == G(v, cumul) IN
@@ -424,7 +424,7 @@ ApaFoldSeqLeft( step, e, Tail(chain) )
 Then, `Op^(x) = NonrecursiveOp(x, N)`. Alternatively,
 
 ```tla
-\* @type (a, Int) => a;
+\* @type (a, Int) => b;
 NonrecursiveOp(x, N) ==
 LET chain == Chain(x, N) IN
 LET step(cumul, v) == G(v, cumul) IN

--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -77,6 +77,7 @@ IsValidBlock(block, node_state) ==
     /\ \A voteMsg \in block.votes: IsValidSigedVoteMessage(voteMsg, node_state)
     /\ LET parent == get_block_from_hash(block.parent_hash, node_state)
        IN parent.slot < block.slot \* Parent has lower slot #
+    /\ block.body /= ""
 
 \* @type: ($proposeMessage, $commonNodeState) => Bool;
 IsValidProposeMessage(msg, node_state) ==
@@ -93,7 +94,7 @@ GenesisBlock == [
         parent_hash |-> "",
         slot        |-> 0,
         votes       |-> {},
-        body        |-> ""
+        body        |-> "genesis"
     ]
     
 \* QUESTION TO REVIEWERS: strict > ?
@@ -110,6 +111,7 @@ IsValidNodeState(node_state) ==
     /\ node_state.identity \in Nodes
     /\ node_state.current_slot >= 0
     /\ node_state.current_slot <= MAX_SLOT
+    /\ "" \notin DOMAIN node_state.view_blocks
     \* Each block must have a unique hash: H(B1) = H(B2) <=> B1 = B2
     /\ \A hash1,hash2 \in DOMAIN node_state.view_blocks: 
         hash1 = hash2 <=> node_state.view_blocks[hash1] = node_state.view_blocks[hash2]

--- a/spec/justified.tla
+++ b/spec/justified.tla
@@ -1,0 +1,212 @@
+---- MODULE justified ----
+
+EXTENDS ffg, Sequences
+
+\* Given a set of votes, returns all of the checkpoints, which appear as sources.
+\* @type: (Set($signedVoteMessage)) => Set($checkpoint);
+Sources(votes) == { vote.message.ffg_source : vote \in votes} 
+
+\* The recursion in is_justified_checkpoint is set up as follows:
+\* To justify checkpoint C, we must look at all votes C1 -> C2, s.t.
+\* C lies between C1 and C2 (definition below), AND C1 is justified.
+\* We define the following operator, which precisely captures this condition, 
+\* save for the recursive justificaiton.
+\* @type: ($signedVoteMessage, $checkpoint, $commonNodeState) => Bool;
+IsVoteInSupportAssumingJustifiedSource(vote, checkpoint, node_state) ==
+    \* TODO: If we end up always doing 1-state model checking, a lot of sub-checks in 
+    \* valid_FFG_vote are already a part of the state validity predicate, and couldbe omitted here 
+    \* to simplify computation
+    /\ valid_FFG_vote(vote, node_state) 
+    /\ vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot
+    \* TODO: If we end up always doing 1-state model checking, we could 
+    \* precompute the relation is_ancestor_descendant_relationship(a,b), for all blocks
+    \* ahead of time as a _function_, s.t. this lookup here becomes a simple access, instead of each of them being
+    \* another pseudo-recursive computation
+    /\ is_ancestor_descendant_relationship(
+        get_block_from_hash(checkpoint.block_hash, node_state),
+        get_block_from_hash(vote.message.ffg_target.block_hash, node_state),
+        node_state
+        )
+    /\ is_ancestor_descendant_relationship(
+        get_block_from_hash(vote.message.ffg_source.block_hash, node_state),
+        get_block_from_hash(checkpoint.block_hash, node_state),
+        node_state
+        )
+
+\* With the predicate, we can filter out the checkpoints that are relevant in one step
+\* @type: ($checkpoint, $commonNodeState) => Set($signedVoteMessage);
+VotesRelevantForOneStepIteration(checkpoint, node_state) == 
+    { vote \in node_state.view_votes: IsVoteInSupportAssumingJustifiedSource(vote, checkpoint, node_state)}
+
+\* Using VotesRelevantForOneStepIteration, we can define, for every initial checkpoint C, 
+\* a sequence of maps M_i. We will refer to the domain elements of M_i as "targets" for step i.
+\* The first map M_1 for C is simply [ c \in {C} |-> VotesRelevantForOneStepIteration(C, ...) ].
+\* Each subsequent map M_{i+1} is defined in the following way:
+\* M_{i+1} ==
+\*     LET newTargets == UNION { Sources(M_i[target]): target \in DOMAIN M_i } 
+\*     IN [ target \in newTargets |-> VotesRelevantForOneStepIteration(target, ...) ]
+ 
+\* This construction is guaranteed to be finite, i.e., there exists some n, s.t. M_k is empty for all k >= n and nonempty
+\* for all 1 < i < n. The reason is as follows:
+\*   1. valid_FFG_vote(vote) requires `vote.message.ffg_source.chkp_slot < vote.message.ffg_target.chkp_slot`
+\*   2. IsVoteInSupportAssumingJustifiedSource requires `vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot`
+\* Therefore, for any checkpoint C, all votes in VotesRelevantForOneStepIteration(C, ..)
+\* have sources with a strictly lower slot number. 
+\* If we take N_i to be the maximal slot number of any sorce of a vote in the codomain of M_i, then
+\* we can easily see that N_i > N_{i+1}.
+\* Since the checkpoint with the lowest slot number is the genesis checkpoint C_G, and 
+\* VotesRelevantForOneStepIteration(C_G, ...) = {}, eventually S_m will be empty.
+
+\* This satisfies our termination requirement from the recursion rule.
+
+\* ============IMPORTANT============
+\* TODO: Instead of computing is_justified_checkpoint for a single checkpoint
+\* we should directly define the set of _ALL_ justified checkpoints for a given state
+\* (which can be justified by all the votes in that state)
+\* =================================
+
+\* Using the above knowledge, we can construct a Chain operator, to compute the sequence <<M_n, ..., M_1>>,
+\* as required by the recursion rule.
+
+\* Our base-case for recursion is whenever C is the genesis block. In the language of vote strata, this means 
+\* whenever the stratum is empty
+
+\* @typeAlias: targetMap = $checkpoint -> Set($signedVoteMessage);
+\* @type: ($targetMap, Int, $commonNodeState) => Seq($targetMap);
+Chain(x, N, node_state) ==
+    LET 
+        \* @type: ($targetMap) => Bool;
+        P(map) == DOMAIN map = {}
+        \* if x = M_i, then b(x) defines M_{i+1}
+        \* @type: ($targetMap) => $targetMap;
+        b(map) ==
+            LET newTargets == UNION { Sources(x[target]): target \in DOMAIN map } 
+            IN [ target \in newTargets |-> VotesRelevantForOneStepIteration(target, node_state) ]
+    IN  LET 
+            \* @type: (Seq($targetMap), Int) => Seq($targetMap);
+            step(seq, i) == 
+                IF P(seq[1])
+                THEN seq
+                ELSE <<b(seq[1])>> \o seq \* Alternatively, we can append here and reverse the list at the end
+        IN ApaFoldSeqLeft( step, <<x>>, MkSeq(N, LAMBDA i: i) )
+        
+
+\* @type: ($targetMap, Int, $commonNodeState) => Set($checkpoint);
+AllJustifiedCheckpoints(initialTargetMap, N, node_state) ==
+    LET chain == Chain(initialTargetMap, N, node_state) IN
+    LET 
+        \* @type: ($targetMap, Set($checkpoint)) => Set($checkpoint);
+        G(currentTargetMap, justifiedCheckpoints) ==
+            LET targets == DOMAIN currentTargetMap IN
+            \* We define the justification filter for one checkpoint, which
+            \* looks at the currently computed set of justifiedCheckpoints
+            \* instead of recursing
+            LET 
+                \* @type: ($checkpoint) => Bool;
+                isOneCheckpointJustified(checkpoint) ==
+                    LET
+                        \* TODO: If we end up always doing 1-state model checking, these two are
+                        \* implied by the sate validity predicate and can be omitted
+                        hasBlockHash == has_block_hash(checkpoint.block_hash, node_state)
+                        isCompleteChain == 
+                            is_complete_chain(
+                                get_block_from_hash(checkpoint.block_hash, node_state), 
+                                node_state
+                            )
+                    IN  LET 
+                        \* TODO: Since GET_VALIDATOR_SET_FOR_SLOT is a constant operator, we could
+                        \* directly substitute it here
+                        validatorBalances == 
+                            GET_VALIDATOR_SET_FOR_SLOT(
+                                get_block_from_hash(checkpoint.block_hash, node_state), 
+                                checkpoint.block_slot, 
+                                node_state
+                            )
+                    IN LET 
+                        FFG_support_weight == 
+                            validator_set_weight(
+                                {
+                                    \* Instead of recursion, we take the 
+                                    \* votes relevant for this target, and filter them by known justified  sources
+                                    filtered_vote.sender : filtered_vote \in  {
+                                        vote \in currentTargetMap[checkpoint] : 
+                                            vote.message.ffg_source \in justifiedCheckpoints
+                                    }
+                                },
+                                validatorBalances
+                            )
+                        \* TODO: This value does not depend on any checkpoint or set of votes, so it is 
+                        \* constant throughout the iteration, assuming validatorBalances is constant as decribed above
+                        tot_validator_set_weight == 
+                            validator_set_weight(DOMAIN validatorBalances, validatorBalances)
+                    IN FFG_support_weight * 3 >= tot_validator_set_weight * 2
+            IN justifiedCheckpoints \union { target \in targets : isOneCheckpointJustified(target) }
+    IN LET step(cumul, v) == G(v, cumul) 
+    IN ApaFoldSeqLeft( step, {genesis_checkpoint(node_state)}, Tail(chain) )
+
+
+\* @type: ($checkpoint, Int, $commonNodeState) => Bool;
+NonrecursiveIsJustifiedCheckpoint(checkpoint, N, node_state) ==
+    LET initialTargetMap == [ c \in {checkpoint} |-> VotesRelevantForOneStepIteration(c, node_state) ]
+    IN checkpoint \in AllJustifiedCheckpoints(initialTargetMap, N, node_state)
+
+
+\* =========================================
+
+\* For comparison, we include the unrolled version of is_justified_checkpoint
+
+\* SRC: https://github.com/saltiniroberto/ssf/blob/ad3ba2c21bc1cd554a870a6e0e4d87040558e129/high_level/common/ffg.py#L84
+\* It checks whether a `checkpoint` if justified, specifically a `checkpoint` is justified if at least
+\* two-thirds of the total validator set weight is in support. This is evaluated by checking if
+\* `FFG_support_weight * 3 >= tot_validator_set_weight * 2`.
+RECURSIVE is_justified_checkpoint_unrolled(_, _)
+\* @type: ($checkpoint, $commonNodeState) => Bool;
+is_justified_checkpoint_unrolled(checkpoint, node_state) ==
+    IF checkpoint = genesis_checkpoint(node_state)
+    THEN TRUE
+    ELSE 
+        LET
+            hasBlockHash == has_block_hash(checkpoint.block_hash, node_state)
+            isCompleteChain == 
+                is_complete_chain(
+                    get_block_from_hash(checkpoint.block_hash, node_state), 
+                    node_state
+                )
+        IN 
+            IF (~hasBlockHash \/ ~isCompleteChain)
+            THEN FALSE
+            ELSE
+                LET 
+                    validatorBalances == 
+                        GET_VALIDATOR_SET_FOR_SLOT(
+                            get_block_from_hash(checkpoint.block_hash, node_state), 
+                            checkpoint.block_slot, 
+                            node_state
+                        )
+                IN LET 
+                    FFG_support_weight == 
+                        validator_set_weight(
+                            {
+                                filtered_vote.sender : filtered_vote \in  {
+                                    vote \in node_state.view_votes: 
+                                        /\ valid_FFG_vote(vote, node_state)
+                                        /\ vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot
+                                        /\ is_ancestor_descendant_relationship(
+                                                get_block_from_hash(checkpoint.block_hash, node_state),
+                                                get_block_from_hash(vote.message.ffg_target.block_hash, node_state),
+                                                node_state
+                                            )
+                                        /\ is_ancestor_descendant_relationship(
+                                                get_block_from_hash(vote.message.ffg_source.block_hash, node_state),
+                                                get_block_from_hash(checkpoint.block_hash, node_state),
+                                                node_state)
+                                        /\ is_justified_checkpoint(vote.message.ffg_source, node_state) 
+                                }
+                            },
+                            validatorBalances
+                        )
+                    tot_validator_set_weight == 
+                        validator_set_weight(DOMAIN validatorBalances, validatorBalances)
+                IN FFG_support_weight * 3 >= tot_validator_set_weight * 2
+
+=====

--- a/spec/justified.tla
+++ b/spec/justified.tla
@@ -4,18 +4,18 @@ EXTENDS ffg, Sequences
 
 \* Given a set of votes, returns all of the checkpoints, which appear as sources.
 \* @type: (Set($signedVoteMessage)) => Set($checkpoint);
-Sources(votes) == { vote.message.ffg_source : vote \in votes} 
+Sources(votes) == { vote.message.ffg_source : vote \in votes }
 
 \* The recursion in is_justified_checkpoint is set up as follows:
 \* To justify checkpoint C, we must look at all votes C1 -> C2, s.t.
 \* C lies between C1 and C2 (definition below), AND C1 is justified.
 \* We define the following operator, which precisely captures this condition, 
-\* save for the recursive justificaiton.
+\* save for the recursive justification.
 \* @type: ($signedVoteMessage, $checkpoint, $commonNodeState) => Bool;
 IsVoteInSupportAssumingJustifiedSource(vote, checkpoint, node_state) ==
     \* TODO: If we end up always doing 1-state model checking, a lot of sub-checks in 
-    \* valid_FFG_vote are already a part of the state validity predicate, and couldbe omitted here 
-    \* to simplify computation
+    \* valid_FFG_vote are already a part of the state validity predicate, and
+    \* could be omitted here to simplify computation.
     /\ valid_FFG_vote(vote, node_state) 
     /\ vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot
     \* TODO: If we end up always doing 1-state model checking, we could 
@@ -47,12 +47,12 @@ VotesRelevantForOneStepIteration(checkpoint, node_state) ==
 \*     IN [ target \in newTargets |-> VotesRelevantForOneStepIteration(target, ...) ]
  
 \* This construction is guaranteed to be finite, i.e., there exists some n, s.t. M_k is empty for all k >= n and nonempty
-\* for all 1 < i < n. The reason is as follows:
+\* for all 1 < i < n. We convince ourselves by first observing that:
 \*   1. valid_FFG_vote(vote) requires `vote.message.ffg_source.chkp_slot < vote.message.ffg_target.chkp_slot`
 \*   2. IsVoteInSupportAssumingJustifiedSource requires `vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot`
 \* Therefore, for any checkpoint C, all votes in VotesRelevantForOneStepIteration(C, ..)
 \* have sources with a strictly lower slot number. 
-\* If we take N_i to be the maximal slot number of any sorce of a vote in a set in the codomain of M_i, then
+\* If we take N_i to be the maximal slot number of any source of a vote in a set in the codomain of M_i, then
 \* we can easily see that N_i > N_{i+1}.
 \* Since the checkpoint with the lowest slot number is the genesis checkpoint C_G, and 
 \* VotesRelevantForOneStepIteration(C_G, ...) = {}, eventually S_m will be empty.

--- a/spec/justified.tla
+++ b/spec/justified.tla
@@ -46,7 +46,7 @@ VotesInSupportAssumingJustifiedSource(checkpoint, node_state) ==
 \* For certain checkpoints, such as for example the genesis checkpoint C_G, as well as 
 \* any checkpoints which do not have any votes in support, this set is empty.
 
-\* Each such checkpoint c_i pending justification requires us to look at VotesInSupportAssumingJustifiedSource(c_i, ...),
+\* Each such checkpoint c pending justification requires us to look at VotesInSupportAssumingJustifiedSource(c, ...),
 \* which in turn gives us another (possibly empty) set of (other) checkpoints that need to be evaluated.
 \* We will show below that this construction necessarily terminates, but for now we note that:
 \*   - in each step, we have a set of relevant checkpoints
@@ -115,7 +115,7 @@ Chain(x, N, node_state) ==
         \* if x = M_i, then b(x) defines M_{i+1}
         \* @type: ($targetMap) => $targetMap;
         b(map) ==
-            LET newTargets == UNION { Sources(x[target]): target \in DOMAIN map } 
+            LET newTargets == UNION { Sources(map[target]): target \in DOMAIN map } 
             IN [ target \in newTargets |-> VotesRelevantForOneStepIteration(target, node_state) ]
     IN  LET 
             \* @type: (Seq($targetMap), Int) => Seq($targetMap);

--- a/spec/justified.tla
+++ b/spec/justified.tla
@@ -116,7 +116,7 @@ Chain(x, N, node_state) ==
         \* @type: ($targetMap) => $targetMap;
         b(map) ==
             LET newTargets == UNION { Sources(map[target]): target \in DOMAIN map } 
-            IN [ target \in newTargets |-> VotesRelevantForOneStepIteration(target, node_state) ]
+            IN [ target \in newTargets |-> VotesInSupportAssumingJustifiedSource(target, node_state) ]
     IN  LET 
             \* @type: (Seq($targetMap), Int) => Seq($targetMap);
             step(seq, i) == 
@@ -184,7 +184,7 @@ AllJustifiedCheckpoints(initialTargetMap, N, node_state) ==
 
 \* @type: ($checkpoint, Int, $commonNodeState) => Bool;
 NonrecursiveIsJustifiedCheckpoint(checkpoint, N, node_state) ==
-    LET initialTargetMap == [ c \in {checkpoint} |-> VotesRelevantForOneStepIteration(c, node_state) ]
+    LET initialTargetMap == [ c \in {checkpoint} |-> VotesInSupportAssumingJustifiedSource(c, node_state) ]
     IN checkpoint \in AllJustifiedCheckpoints(initialTargetMap, N, node_state)
 
 

--- a/spec/justified.tla
+++ b/spec/justified.tla
@@ -47,22 +47,22 @@ VotesInSupportAssumingJustifiedSource(checkpoint, node_state) ==
 \* any checkpoints which do not have any votes in support, this set is empty.
 
 \* Each such checkpoint c pending justification requires us to look at VotesInSupportAssumingJustifiedSource(c, ...),
-\* which in turn gives us another (possibly empty) set of (other) checkpoints that need to be evaluated.
+\* which in turn gives us another (possibly empty) set of (other) checkpoints, the justification of which needs to be evaluated.
 \* We will show below that this construction necessarily terminates, but for now we note that:
 \*   - in each step, we have a set of relevant checkpoints
 \*   - for each of these checkpoints, we need to keep track of a set of votes potentially justifying it, 
-\*     which will be used to define the checkpoints in the next step
+\*     the sources of which define the checkpoints in the next step
 
 \* Due to the above, we observe that we can define a (finite) sequence of _maps_ s.t.:
 \*   - The domain of the i-th map is exactly the set of checkpoints pending justification in the i-th step
 \*   - Each checkpoint in this domain maps to the set of votes used to potentially justify it
 
-\* Let CheckpointsPendingJustification_i denote the set of checkpoints we need to be able to justify in the i-th step
+\* Let CheckpointsPendingJustification_i denote the set of checkpoints for which we need to be able to evaluate justification in the i-th step
 \* Initially, CheckpointsPendingJustification_1 = { C }, i.e. the original checkpoint C
 \* To formalize the construction described above, CheckpointsPendingJustification_{i+1} will contain the sources of 
 \* all checkpoints, used by votes in support of any of the checkpoints in CheckpointsPendingJustification_i:
 \* CheckpointsPendingJustification_{i+1} ==
-\*     UNION { Sources(VotesInSupportAssumingJustifiedSource(c_j, ...)) : c_j \in CheckpointsPendingJustification_i }
+\*     UNION { Sources(VotesInSupportAssumingJustifiedSource(c, ...)) : c \in CheckpointsPendingJustification_i }
 
 \* Finally, we extend this notion to a sequence of maps M_i,
 \* where the domain of M_i is CheckpointsPendingJustification_i, and

--- a/spec/justified.tla
+++ b/spec/justified.tla
@@ -33,7 +33,7 @@ IsVoteInSupportAssumingJustifiedSource(vote, checkpoint, node_state) ==
         node_state
         )
 
-\* With the predicate, we can filter out the checkpoints that are relevant in one step
+\* With the predicate, we can filter out the votes that are relevant in one step
 \* @type: ($checkpoint, $commonNodeState) => Set($signedVoteMessage);
 VotesRelevantForOneStepIteration(checkpoint, node_state) == 
     { vote \in node_state.view_votes: IsVoteInSupportAssumingJustifiedSource(vote, checkpoint, node_state)}
@@ -52,7 +52,7 @@ VotesRelevantForOneStepIteration(checkpoint, node_state) ==
 \*   2. IsVoteInSupportAssumingJustifiedSource requires `vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot`
 \* Therefore, for any checkpoint C, all votes in VotesRelevantForOneStepIteration(C, ..)
 \* have sources with a strictly lower slot number. 
-\* If we take N_i to be the maximal slot number of any sorce of a vote in the codomain of M_i, then
+\* If we take N_i to be the maximal slot number of any sorce of a vote in a set in the codomain of M_i, then
 \* we can easily see that N_i > N_{i+1}.
 \* Since the checkpoint with the lowest slot number is the genesis checkpoint C_G, and 
 \* VotesRelevantForOneStepIteration(C_G, ...) = {}, eventually S_m will be empty.
@@ -67,9 +67,6 @@ VotesRelevantForOneStepIteration(checkpoint, node_state) ==
 
 \* Using the above knowledge, we can construct a Chain operator, to compute the sequence <<M_n, ..., M_1>>,
 \* as required by the recursion rule.
-
-\* Our base-case for recursion is whenever C is the genesis block. In the language of vote strata, this means 
-\* whenever the stratum is empty
 
 \* @typeAlias: targetMap = $checkpoint -> Set($signedVoteMessage);
 \* @type: ($targetMap, Int, $commonNodeState) => Seq($targetMap);


### PR DESCRIPTION
Based on the recursion rules introduced in #17, this PR adds a nonrecursive implementation of `is_justified_checkpoint`. Justification of iteration values is included in the file comments. Also includes a minor type generalization in the rule itself.