### PR TITLE
Add Makefile with (type)checking commands

### DIFF
--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,0 +1,14 @@
+typecheck:
+	apalache-mc typecheck ffg.tla
+
+	# alternative implementations of recursive operators
+	apalache-mc typecheck ffg_recursive.tla
+	apalache-mc typecheck helpers_recursive.tla
+
+check:
+	apalache-mc check --length=0 --inv=NoSlashableInv MC_ffg.tla
+
+clean:
+	rm -rf _apalache-out/
+
+.PHONY: clean typecheck


### PR DESCRIPTION
Add a Makefile with targets

- `typecheck`: runs `apalache-mc typecheck`, including on the recursive implementations
- `clean`: cleanup of apalache output
- `check`: a prelimiary `check` command