### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+# Force platform to linux/amd64; there is no Z3 release for linux/arm64:
+# https://github.com/Z3Prover/z3/issues/7201
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/java:21-bullseye
+
+RUN wget -qO- https://github.com/apalache-mc/apalache/releases/download/v0.44.11/apalache.tgz | tar xz -C /opt/
+ENV PATH="/opt/apalache/bin/:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// A dev container for model-checking the Python spec.
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "SSF-MC",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"alygin.vscode-tlaplus-nightly",
+				"informal.itf-trace-viewer",
+				"ms-python.python",
+				"vscodevim.vim"
+			],
+			"settings": {
+				"extensions.ignoreRecommendations": true, // don't show recommendations for extensions
+				"terminal.integrated.copyOnSelection": true
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add a VSCode [dev container](https://code.visualstudio.com/docs/devcontainers/containers) that sets up Apalache, plus Python and TLA+ extensions.