### PR TITLE
Fix & tighten bounds on folds

### DIFF
--- a/Translation.md
+++ b/Translation.md
@@ -407,7 +407,7 @@ Chain(x, N) ==
       IF P(seq[1])
       THEN seq
       ELSE <<b(seq[1])>> \o seq \* Alternatively, we can append here and reverse the list at the end
-  IN ApaFoldSeqLeft( step, <<x>>, MkSeq(N, LAMBDA i: i) )
+  IN ApaFoldSet( step, <<x>>, 1..N )
 ```
 We can see that `Chain(x,N)` returns the sequence `<<v_n, ..., x>>` if `N` is sufficiently large. We can verify whether or not that is the case, by evaluating `P(Chain(x, N)[1])`. If it does not hold, the `N` chosen is not large enough, and needs to be increased.
 

--- a/Translation.md
+++ b/Translation.md
@@ -407,7 +407,7 @@ Chain(x, N) ==
       IF P(seq[1])
       THEN seq
       ELSE <<b(seq[1])>> \o seq \* Alternatively, we can append here and reverse the list at the end
-  IN ApaFoldSet( step, <<x>>, 1..N )
+  IN ApaFoldSeqLeft( step, <<x>>, MkSeq(N, LAMBDA i: i) )
 ```
 We can see that `Chain(x,N)` returns the sequence `<<v_n, ..., x>>` if `N` is sufficiently large. We can verify whether or not that is the case, by evaluating `P(Chain(x, N)[1])`. If it does not hold, the `N` chosen is not large enough, and needs to be increased.
 

--- a/spec/ffg.tla
+++ b/spec/ffg.tla
@@ -281,7 +281,7 @@ Chain(x, node_state, N) ==
                 IF P(seq[1])
                 THEN seq
                 ELSE <<b(seq[1])>> \o seq \* Alternatively, we can append here and reverse the list at the end
-        IN ApaFoldSet( step, <<x>>, 1..N )
+        IN ApaFoldSeqLeft( step, <<x>>, MkSeq(N, (* @type: Int => Int; *) LAMBDA i: i) )
 
 \* @type: ($targetMap, $commonNodeState, Int) => Set($checkpoint);
 AllJustifiedCheckpoints(initialTargetMap, node_state, N) ==

--- a/spec/ffg.tla
+++ b/spec/ffg.tla
@@ -281,7 +281,7 @@ Chain(x, node_state, N) ==
                 IF P(seq[1])
                 THEN seq
                 ELSE <<b(seq[1])>> \o seq \* Alternatively, we can append here and reverse the list at the end
-        IN ApaFoldSeqLeft( step, <<x>>, MkSeq(N, LAMBDA i: i) )
+        IN ApaFoldSet( step, <<x>>, 1..N )
 
 \* @type: ($targetMap, $commonNodeState, Int) => Set($checkpoint);
 AllJustifiedCheckpoints(initialTargetMap, node_state, N) ==
@@ -345,7 +345,7 @@ AllJustifiedCheckpoints(initialTargetMap, node_state, N) ==
 \* @type: ($checkpoint, $commonNodeState) => Bool;
 is_justified_checkpoint(checkpoint, node_state) ==
     LET initialTargetMap == [ c \in {checkpoint} |-> VotesInSupportAssumingJustifiedSource(c, node_state) ]
-    IN checkpoint \in AllJustifiedCheckpoints(initialTargetMap, node_state, checkpoint.chkp_slot)
+    IN checkpoint \in AllJustifiedCheckpoints(initialTargetMap, node_state, MAX_SLOT)
 
 \* For comparison, we include the unrolled version of is_justified_checkpoint
 RECURSIVE is_justified_checkpoint_unrolled(_, _)

--- a/spec/helpers.tla
+++ b/spec/helpers.tla
@@ -153,11 +153,11 @@ is_ancestor_descendant_relationship(ancestor, descendant, node_state) ==
     FindAncestor(last_block_and_flag, slot) ==
         LET last_block == last_block_and_flag[1] IN
         LET flag == last_block_and_flag[2] IN
-        IF last_block = ancestor \/ flag THEN Pair(last_block, TRUE)
+        IF flag THEN Pair(last_block, TRUE)
         ELSE IF last_block = node_state.configuration.genesis \/ ~has_parent(last_block, node_state) THEN Pair(last_block, FALSE)
-        ELSE Pair(get_parent(last_block, node_state), FALSE)
+        ELSE LET parent == get_parent(last_block, node_state) IN Pair(parent, parent = ancestor)
     IN
-    ApaFoldSet( FindAncestor, Pair(descendant, FALSE), 0..MAX_SLOT )[2]
+    ApaFoldSet( FindAncestor, Pair(descendant, descendant = ancestor), 1..MAX_SLOT )[2]
 
 (*
  * Filter blocks, retaining only those that are ancestors of a specified block.

--- a/spec/helpers.tla
+++ b/spec/helpers.tla
@@ -131,7 +131,7 @@ get_blockchain(block, node_state) ==
             LET parent == get_parent(last_block, node_state) IN
             Pair(parent, Push(chain_upto_slot, parent))
     IN
-    ApaFoldSet( ChainWithParent, Pair(block, List(<< block >>)), 1..MAX_SLOT )[2]
+    ApaFoldSeqLeft( ChainWithParent, Pair(block, List(<< block >>)), MkSeq(MAX_SLOT, (* @type: Int => Int; *) LAMBDA i: i) )[2]
 
 \* @type: ($block, $commonNodeState) => Bool;
 is_complete_chain(block, node_state) ==
@@ -157,7 +157,7 @@ is_ancestor_descendant_relationship(ancestor, descendant, node_state) ==
         ELSE IF last_block = node_state.configuration.genesis \/ ~has_parent(last_block, node_state) THEN Pair(last_block, FALSE)
         ELSE LET parent == get_parent(last_block, node_state) IN Pair(parent, parent = ancestor)
     IN
-    ApaFoldSet( FindAncestor, Pair(descendant, descendant = ancestor), 1..MAX_SLOT )[2]
+    ApaFoldSeqLeft( FindAncestor, Pair(descendant, descendant = ancestor), MkSeq(MAX_SLOT, (* @type: Int => Int; *) LAMBDA i: i) )[2]
 
 (*
  * Filter blocks, retaining only those that are ancestors of a specified block.
@@ -187,7 +187,7 @@ have_common_ancestor(chain1, chain2, node_state) ==
                 LET parent == get_parent(last_block, node_state) IN
                 Pair(parent, chain_upto_slot \union { parent })
         IN
-        ApaFoldSet( ChainWithParent, Pair(block, { block }), 1..MAX_SLOT )[2]
+        ApaFoldSeqLeft( ChainWithParent, Pair(block, { block }), MkSeq(MAX_SLOT, (* @type: Int => Int; *) LAMBDA i: i) )[2]
     IN
     get_blockchain_set(chain1) \intersect get_blockchain_set(chain2) # {}
 

--- a/spec/helpers.tla
+++ b/spec/helpers.tla
@@ -38,13 +38,6 @@ CONSTANTS
 Last(lst) == At(lst, (Size(lst) - 1))
 
 (*
- * Slots that Apalache should fold over when traversing ancestors.
- *
- * @type: $commonNodeState => Set(Int);
- *)
-ApalacheFoldSlots(node_state) == { i \in 0..MAX_SLOT: i <= node_state.current_slot }
-
-(*
  * Checkpoint for the genesis block.
  * 
  * @type: $commonNodeState => $checkpoint;
@@ -138,7 +131,7 @@ get_blockchain(block, node_state) ==
             LET parent == get_parent(last_block, node_state) IN
             Pair(parent, Push(chain_upto_slot, parent))
     IN
-    ApaFoldSet( ChainWithParent, Pair(block, List(<< block >>)), ApalacheFoldSlots(node_state) )[2]
+    ApaFoldSet( ChainWithParent, Pair(block, List(<< block >>)), 1..MAX_SLOT )[2]
 
 \* @type: ($block, $commonNodeState) => Bool;
 is_complete_chain(block, node_state) ==
@@ -164,7 +157,7 @@ is_ancestor_descendant_relationship(ancestor, descendant, node_state) ==
         ELSE IF last_block = node_state.configuration.genesis \/ ~has_parent(last_block, node_state) THEN Pair(last_block, FALSE)
         ELSE Pair(get_parent(last_block, node_state), FALSE)
     IN
-    ApaFoldSet( FindAncestor, Pair(descendant, FALSE), ApalacheFoldSlots(node_state) )[2]
+    ApaFoldSet( FindAncestor, Pair(descendant, FALSE), 0..MAX_SLOT )[2]
 
 (*
  * Filter blocks, retaining only those that are ancestors of a specified block.
@@ -194,7 +187,7 @@ have_common_ancestor(chain1, chain2, node_state) ==
                 LET parent == get_parent(last_block, node_state) IN
                 Pair(parent, chain_upto_slot \union { parent })
         IN
-        ApaFoldSet( ChainWithParent, Pair(block, { block }), ApalacheFoldSlots(node_state) )[2]
+        ApaFoldSet( ChainWithParent, Pair(block, { block }), 1..MAX_SLOT )[2]
     IN
     get_blockchain_set(chain1) \intersect get_blockchain_set(chain2) # {}
 


### PR DESCRIPTION
Fix and tighten the bounds on folds.

**For helpers.tla:**

1. We currently use `{ i \in 0..MAX_SLOT: i <= node_state.current_slot }` to fold over.
However, we don't constrain `single_node_state.current_slot` in `Init`, so the additional filter is unsound. We replace it with just `0..MAX_SLOT`.

2. The bounds on `get_blockchain` and `have_common_ancestor` can be tightened to `1..MAX_SLOT`.

3. For `is_ancestor_descendant_relationship` we do the same by pulling the comparison one step out of the fold.

**For ffg.tla:**

1. Replace non-constant `checkpoint.chkp_slot` with `MAX_SLOT`.
2. `ApaFoldSeqLeft` over `MkSeq` would require a type annotation on the lambda. Replace it with `ApaFoldSet` over `1..N` to emphasize that order of the underlying structure is irrelevant.