### PR TITLE
Refine initial state

### DIFF
--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -132,7 +132,7 @@ IsValidConfiguration(cfg, node_state) ==
 \* @type: ($hash -> $block, $commonNodeState) => Bool;
 IsValidBlockView(view_blocks, node_state) ==
     \* Assign readable names to block hashes introduced as fresh constants by Apalache
-    /\ DOMAIN single_node_state.view_blocks \subseteq BlockHashes \union { GenesisBlock.body }
+    /\ DOMAIN node_state.view_blocks \subseteq BlockHashes \union { GenesisBlock.body }
     \* The genesis block is always in the block view, it's parent hash never
     /\ view_blocks[GenesisBlock.body] = GenesisBlock
     /\ GenesisBlock.parent_hash \notin DOMAIN view_blocks

--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -10,7 +10,11 @@
 Nodes == { "A", "B", "C", "D" }
 
 \* Model-checking: Maximum slot (inclusive) that Apalache folds over when traversing ancestors.
-MAX_SLOT == 5
+\* Let `genesis <- b1 <- ... <- bn` be the longest chain from genesis in `view_votes`. Then `MAX_SLOT` MUST be at least `n`.
+MAX_SLOT == 4
+
+\* Model-checking: Maximum number of votes in `view_votes`.
+MAX_VOTES == 6
 
 \* ========== Dummy implementations of stubs ==========
 
@@ -146,7 +150,15 @@ IsValidNodeState(node_state) ==
 \* Start in some arbitrary state
 \* @type: () => Bool;
 Init == 
-    /\ single_node_state = Gen(5)
+    LET
+        config == Gen(1)
+        id     == Gen(1)
+        current_slot == MAX_SLOT
+        view_blocks  == Gen(MAX_SLOT + 1)  \* MAX_SLOT "regular" blocks + 1 for genesis (at slot 0)
+        view_votes   == Gen(MAX_VOTES)
+        chava  == Gen(1)
+    IN
+    /\ single_node_state = [ configuration |-> config, identity |-> id, current_slot |-> current_slot, view_blocks |-> view_blocks, view_votes |-> view_votes, chava |-> chava ]
     /\ IsValidNodeState(single_node_state)
 
 Next == UNCHANGED single_node_state

--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -123,10 +123,12 @@ IsValidConfiguration(cfg, node_state) ==
 
 \* @type: ($hash -> $block, $commonNodeState) => Bool;
 IsValidBlockView(view_blocks, node_state) ==
-    /\ "" \notin DOMAIN node_state.view_blocks
+    \* The genesis block is always in the block view, it's parent hash never
+    /\ view_blocks[GenesisBlock.body] = GenesisBlock
+    /\ GenesisBlock.parent_hash \notin DOMAIN view_blocks
     \* Each block must have a unique hash: H(B1) = H(B2) <=> B1 = B2
-    /\ \A hash1,hash2 \in DOMAIN node_state.view_blocks: 
-        hash1 = hash2 <=> node_state.view_blocks[hash1] = node_state.view_blocks[hash2]
+    /\ \A hash1,hash2 \in DOMAIN view_blocks:
+        hash1 = hash2 <=> view_blocks[hash1] = view_blocks[hash2]
 
 \* @type: ($commonNodeState) => Bool;
 IsValidNodeState(node_state) ==

--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -121,16 +121,20 @@ IsValidConfiguration(cfg, node_state) ==
     /\ cfg.eta >= 1
     /\ cfg.k >= 0
 
+\* @type: ($hash -> $block, $commonNodeState) => Bool;
+IsValidBlockView(view_blocks, node_state) ==
+    /\ "" \notin DOMAIN node_state.view_blocks
+    \* Each block must have a unique hash: H(B1) = H(B2) <=> B1 = B2
+    /\ \A hash1,hash2 \in DOMAIN node_state.view_blocks: 
+        hash1 = hash2 <=> node_state.view_blocks[hash1] = node_state.view_blocks[hash2]
+
 \* @type: ($commonNodeState) => Bool;
 IsValidNodeState(node_state) ==
     /\ IsValidConfiguration(node_state.configuration, node_state)
     /\ node_state.identity \in Nodes
     /\ node_state.current_slot >= 0
     /\ node_state.current_slot <= MAX_SLOT
-    /\ "" \notin DOMAIN node_state.view_blocks
-    \* Each block must have a unique hash: H(B1) = H(B2) <=> B1 = B2
-    /\ \A hash1,hash2 \in DOMAIN node_state.view_blocks: 
-        hash1 = hash2 <=> node_state.view_blocks[hash1] = node_state.view_blocks[hash2]
+    /\ IsValidBlockView(node_state.view_blocks, node_state)
     /\ \A msg \in node_state.view_votes: IsValidSigedVoteMessage(msg, node_state)
     /\ IsValidBlock(node_state.chava, node_state)
 

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -6,7 +6,7 @@ typecheck:
 	apalache-mc typecheck helpers_recursive.tla
 
 check:
-	apalache-mc check --length=0 --inv=NoSlashableInv MC_ffg.tla
+	apalache-mc check --length=0 --discard-disabled=true --inv=Inv MC_ffg.tla
 
 clean:
 	rm -rf _apalache-out/


### PR DESCRIPTION
Makes a few adaptions on the initial state:

1. Split the generator size into 2 separate constants, `MAX_SLOT` for blocks and `MAX_VOTES` for FFG votes
2. Force block hashes into a set of readable strings (to avoid meaningless `"FRESHxxx"` string literals in counterexamples)
3. Add a constraint to ensure that the genesis block is in `view_blocks`