### PR TITLE
Precompute fold-based operators

### DIFF
--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -163,6 +163,13 @@ IsValidNodeState(node_state) ==
 \* State machine
 \* ==================================================================
 
+\* The following variables encode precomputed sets, to avoid emitting nested folds
+Precompute ==
+    LET all_blocks == get_all_blocks(single_node_state) IN
+        /\ PRECOMPUTED__IS_COMPLETE_CHAIN =
+            { block \in all_blocks : is_complete_chain(block, single_node_state) }
+        /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP =
+            [ descendant \in all_blocks |-> { ancestor \in all_blocks : is_ancestor_descendant_relationship(ancestor, descendant, single_node_state) } ]
 
 \* Start in some arbitrary state
 Init ==
@@ -175,12 +182,8 @@ Init ==
         chava  == Gen(1)
     IN
     /\ single_node_state = [ configuration |-> config, identity |-> id, current_slot |-> current_slot, view_blocks |-> view_blocks, view_votes |-> view_votes, chava |-> chava ]
+    /\ Precompute
     /\ IsValidNodeState(single_node_state)
-    /\ LET all_blocks == get_all_blocks(single_node_state) IN
-        /\ PRECOMPUTED__IS_COMPLETE_CHAIN =
-            { block \in all_blocks : is_complete_chain(block, single_node_state) }
-        /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP =
-            [ descendant \in all_blocks |-> { ancestor \in all_blocks : is_ancestor_descendant_relationship(ancestor, descendant, single_node_state) } ]
 
 Next == UNCHANGED <<single_node_state, PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP, PRECOMPUTED__IS_COMPLETE_CHAIN>>
 

--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -48,9 +48,6 @@ GET_VALIDATOR_SET_FOR_SLOT(block, slot, node_state) == [node \in Nodes |-> 100]
 VARIABLES
     \* @type: $commonNodeState;
     single_node_state,
-    \* A precomputed set of blocks that form complete chains.
-    \* @type: Set($block);
-    PRECOMPUTED__IS_COMPLETE_CHAIN,
     \* A precomputed map from (descendant) blocks to their ancestors.
     \* @type: $block -> Set($block);
     PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP,
@@ -65,14 +62,6 @@ INSTANCE ffg WITH
     GET_VALIDATOR_SET_FOR_SLOT <- GET_VALIDATOR_SET_FOR_SLOT
 
 \* ========== Shape-requirements for state-variable fields ==========
-
-\* @type: $block;
-GenesisBlock == [
-        parent_hash |-> "",
-        slot        |-> 0,
-        votes       |-> {},
-        body        |-> "genesis"
-    ]
 
 \* Readable names for block hashes (introduced as fresh constants by Apalache). `BlockHashes` must satisfy |BlockHashes| >= |DOMAIN view_blocks|
 BlockHashes == { BLOCK_HASH(GenesisBlock), "BLOCK1", "BLOCK2", "BLOCK3", "BLOCK4", "BLOCK5", "BLOCK6", "BLOCK7", "BLOCK8", "BLOCK9", "BLOCK10" }
@@ -169,8 +158,6 @@ IsValidNodeState(node_state) ==
 \* The following variables encode precomputed sets, to avoid emitting nested folds
 Precompute ==
     LET all_blocks == get_all_blocks(single_node_state) IN
-        /\ PRECOMPUTED__IS_COMPLETE_CHAIN =
-            { block \in all_blocks : is_complete_chain(block, single_node_state) }
         /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP =
             [ descendant \in all_blocks |-> { ancestor \in all_blocks : is_ancestor_descendant_relationship(ancestor, descendant, single_node_state) } ]
         /\ LET
@@ -196,7 +183,7 @@ Init ==
     /\ Precompute
     /\ IsValidNodeState(single_node_state)
 
-Next == UNCHANGED <<single_node_state, PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP, PRECOMPUTED__IS_COMPLETE_CHAIN, PRECOMPUTED__IS_JUSTIFIED_CHECKPOINT>>
+Next == UNCHANGED <<single_node_state, PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP, PRECOMPUTED__IS_JUSTIFIED_CHECKPOINT>>
 
 \* ==================================================================
 \* Invariants

--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -48,6 +48,9 @@ GET_VALIDATOR_SET_FOR_SLOT(block, slot, node_state) == [node \in Nodes |-> 100]
 VARIABLES
     \* @type: $commonNodeState;
     single_node_state,
+    \* A precomputed set of blocks that form complete chains.
+    \* @type: Set($block);
+    PRECOMPUTED__IS_COMPLETE_CHAIN,
     \* A precomputed map from (descendant) blocks to their ancestors.
     \* @type: $block -> Set($block);
     PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP
@@ -173,11 +176,13 @@ Init ==
     IN
     /\ single_node_state = [ configuration |-> config, identity |-> id, current_slot |-> current_slot, view_blocks |-> view_blocks, view_votes |-> view_votes, chava |-> chava ]
     /\ IsValidNodeState(single_node_state)
-    /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP =
-        [ descendant \in all_blocks |-> { ancestor \in all_blocks : is_ancestor_descendant_relationship(ancestor, descendant, single_node_state) } ]
+    /\ LET all_blocks == get_all_blocks(single_node_state) IN
+        /\ PRECOMPUTED__IS_COMPLETE_CHAIN =
+            { block \in all_blocks : is_complete_chain(block, single_node_state) }
+        /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP =
+            [ descendant \in all_blocks |-> { ancestor \in all_blocks : is_ancestor_descendant_relationship(ancestor, descendant, single_node_state) } ]
 
-
-Next == UNCHANGED <<single_node_state, PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP>>
+Next == UNCHANGED <<single_node_state, PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP, PRECOMPUTED__IS_COMPLETE_CHAIN>>
 
 \* ==================================================================
 \* Invariants

--- a/spec/ffg.tla
+++ b/spec/ffg.tla
@@ -297,7 +297,7 @@ AllJustifiedCheckpoints(initialTargetMap, node_state, N) ==
                         \* implied by the sate validity predicate and can be omitted
                         hasBlockHash == has_block_hash(checkpoint.block_hash, node_state)
                         isCompleteChain ==
-                            is_complete_chain(
+                            PRECOMPUTED__is_complete_chain(
                                 get_block_from_hash(checkpoint.block_hash, node_state),
                                 node_state
                             )

--- a/spec/ffg.tla
+++ b/spec/ffg.tla
@@ -124,7 +124,7 @@ valid_FFG_vote(vote, node_state) ==
                 node_state
             )
         )
-    /\ is_ancestor_descendant_relationship(
+    /\ PRECOMPUTED__is_ancestor_descendant_relationship(
             get_block_from_hash(vote.message.ffg_source.block_hash, node_state),
             get_block_from_hash(vote.message.ffg_target.block_hash, node_state),
             node_state
@@ -162,16 +162,12 @@ IsVoteInSupportAssumingJustifiedSource(vote, checkpoint, node_state) ==
     \* could be omitted here to simplify computation.
     /\ valid_FFG_vote(vote, node_state)
     /\ vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot
-    \* TODO: If we end up always doing 1-state model checking, we could
-    \* precompute the relation is_ancestor_descendant_relationship(a,b), for all blocks
-    \* ahead of time as a _function_, s.t. this lookup here becomes a simple access, instead of each of them being
-    \* another pseudo-recursive computation
-    /\ is_ancestor_descendant_relationship(
+    /\ PRECOMPUTED__is_ancestor_descendant_relationship(
         get_block_from_hash(checkpoint.block_hash, node_state),
         get_block_from_hash(vote.message.ffg_target.block_hash, node_state),
         node_state
         )
-    /\ is_ancestor_descendant_relationship(
+    /\ PRECOMPUTED__is_ancestor_descendant_relationship(
         get_block_from_hash(vote.message.ffg_source.block_hash, node_state),
         get_block_from_hash(checkpoint.block_hash, node_state),
         node_state
@@ -380,12 +376,12 @@ is_justified_checkpoint_unrolled(checkpoint, node_state) ==
                                     vote \in node_state.view_votes:
                                         /\ valid_FFG_vote(vote, node_state)
                                         /\ vote.message.ffg_target.chkp_slot = checkpoint.chkp_slot
-                                        /\ is_ancestor_descendant_relationship(
+                                        /\ PRECOMPUTED__is_ancestor_descendant_relationship(
                                                 get_block_from_hash(checkpoint.block_hash, node_state),
                                                 get_block_from_hash(vote.message.ffg_target.block_hash, node_state),
                                                 node_state
                                             )
-                                        /\ is_ancestor_descendant_relationship(
+                                        /\ PRECOMPUTED__is_ancestor_descendant_relationship(
                                                 get_block_from_hash(vote.message.ffg_source.block_hash, node_state),
                                                 get_block_from_hash(checkpoint.block_hash, node_state),
                                                 node_state)

--- a/spec/helpers.tla
+++ b/spec/helpers.tla
@@ -31,6 +31,9 @@ CONSTANTS
     MAX_SLOT
 
 VARIABLES
+    \* A precomputed set of blocks that form complete chains.
+    \* @type: Set($block);
+    PRECOMPUTED__IS_COMPLETE_CHAIN,
     \* A precomputed map from (descendant) blocks to their ancestors.
     \* @type: $block -> Set($block);
     PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP
@@ -144,6 +147,10 @@ is_complete_chain(block, node_state) ==
     \* with a fold similar to above, but reducing to a boolean flag indicating
     \* if it has seen the genesis block. Choosing this version now for brevity.
     Last(get_blockchain(block, node_state)) = node_state.configuration.genesis
+
+\* A precomputed version of `is_complete_chain`, to avoid emitting folds.
+\* @type: ($block, $commonNodeState) => Bool;
+PRECOMPUTED__is_complete_chain(block, node_state) == block \in PRECOMPUTED__IS_COMPLETE_CHAIN
 
 (*
  * Determine if there is an ancestor-descendant relationship between two blocks.

--- a/spec/helpers.tla
+++ b/spec/helpers.tla
@@ -31,12 +31,17 @@ CONSTANTS
     MAX_SLOT
 
 VARIABLES
-    \* A precomputed set of blocks that form complete chains.
-    \* @type: Set($block);
-    PRECOMPUTED__IS_COMPLETE_CHAIN,
     \* A precomputed map from (descendant) blocks to their ancestors.
     \* @type: $block -> Set($block);
     PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP
+
+\* @type: $block;
+GenesisBlock == [
+        parent_hash |-> "",
+        slot        |-> 0,
+        votes       |-> {},
+        body        |-> "genesis"
+    ]
 
 (*
  * The last element of a list.
@@ -150,7 +155,7 @@ is_complete_chain(block, node_state) ==
 
 \* A precomputed version of `is_complete_chain`, to avoid emitting folds.
 \* @type: ($block, $commonNodeState) => Bool;
-PRECOMPUTED__is_complete_chain(block, node_state) == block \in PRECOMPUTED__IS_COMPLETE_CHAIN
+PRECOMPUTED__is_complete_chain(block, node_state) == GenesisBlock \in PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP[block]
 
 (*
  * Determine if there is an ancestor-descendant relationship between two blocks.

--- a/spec/helpers.tla
+++ b/spec/helpers.tla
@@ -30,6 +30,11 @@ CONSTANTS
      *)
     MAX_SLOT
 
+VARIABLES
+    \* A precomputed map from (descendant) blocks to their ancestors.
+    \* @type: $block -> Set($block);
+    PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP
+
 (*
  * The last element of a list.
  *
@@ -159,13 +164,18 @@ is_ancestor_descendant_relationship(ancestor, descendant, node_state) ==
     IN
     ApaFoldSeqLeft( FindAncestor, Pair(descendant, descendant = ancestor), MkSeq(MAX_SLOT, (* @type: Int => Int; *) LAMBDA i: i) )[2]
 
+\* A precomputed version of `is_ancestor_descendant_relationship`, to avoid emitting folds.
+\* @type: ($block, $block, $commonNodeState) => Bool;
+PRECOMPUTED__is_ancestor_descendant_relationship(ancestor, descendant, node_state) ==
+    ancestor \in PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP[descendant]
+
 (*
  * Filter blocks, retaining only those that are ancestors of a specified block.
  *
  * @type: ($block, Set($block), $commonNodeState) => Set($block);
  *)
 filter_out_blocks_non_ancestor_of_block(block, blocks, node_state) ==
-    { b \in blocks: is_ancestor_descendant_relationship(b, block, node_state) }
+    { b \in blocks: PRECOMPUTED__is_ancestor_descendant_relationship(b, block, node_state) }
 
 (*
  * Check if two blocks have a common ancestor.
@@ -199,7 +209,7 @@ have_common_ancestor(chain1, chain2, node_state) ==
  * @type: ($block, $block, $commonNodeState) => Bool;
  *)
 are_conflicting(chain1, chain2, node_state) ==
-    /\ ~is_ancestor_descendant_relationship(chain1, chain2, node_state)
-    /\ ~is_ancestor_descendant_relationship(chain2, chain1, node_state)
+    /\ ~PRECOMPUTED__is_ancestor_descendant_relationship(chain1, chain2, node_state)
+    /\ ~PRECOMPUTED__is_ancestor_descendant_relationship(chain2, chain1, node_state)
 
 =====


### PR DESCRIPTION
With the current specification, Apalache goes out-of-memory even if Java heap size is increased to 20GiB.

This PR precomputes expensive fold-based operators in variables, s.t. they are only emitted once.

Three strategies for constructing the precomputes were implemented and benchmarked (a fourth – not benchmarked – can be found in https://github.com/freespek/ssf-mc/commit/494851ecdc802938313f6b56934cd3191f2770c2).

<details>

```tla
\* The following variables encode precomputed sets, to avoid emitting nested folds
Precompute_Naive ==
    LET all_blocks == get_all_blocks(single_node_state) IN
        /\ PRECOMPUTED__IS_COMPLETE_CHAIN =
            { block \in all_blocks : is_complete_chain(block, single_node_state) }
        /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP =
            [ descendant \in all_blocks |-> { ancestor \in all_blocks : is_ancestor_descendant_relationship(ancestor, descendant, single_node_state) } ]

Precompute_Fixpoint ==
    LET all_blocks == get_all_blocks(single_node_state) IN
        /\ PRECOMPUTED__IS_COMPLETE_CHAIN =
            LET
                \* Update single-step completeness
                \* @type: (Set($block), Int) => Set($block);
                UpdateCompletenessFromParent(aggregate, i) == { block \in all_blocks : block \in aggregate \/ (has_parent(block, single_node_state) /\ get_parent(block, single_node_state) \in aggregate) }
            IN ApaFoldSeqLeft( UpdateCompletenessFromParent, { GenesisBlock }, MkSeq(MAX_SLOT, (* @type: Int => Int; *) LAMBDA i: i) )
        /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP =
            LET
                \* Add single-step ancestors to the aggregate
                \* @type: ($block -> Set($block), Int) => $block -> Set($block);
                AddAncestorsOfParents(aggregate, i) == [ block \in all_blocks |-> IF has_parent(block, single_node_state) THEN aggregate[block] \union aggregate[get_parent(block, single_node_state)] ELSE aggregate[block] ]
            IN ApaFoldSeqLeft( AddAncestorsOfParents, [ block \in all_blocks |-> { block } ], MkSeq(MAX_SLOT, (* @type: Int => Int; *) LAMBDA i: i) )

Precompute_Horizon ==
    LET all_blocks == get_all_blocks(single_node_state) IN
        /\ PRECOMPUTED__IS_COMPLETE_CHAIN =
            LET \* @type: (<<Set($block), Set($block)>>, Int) => <<Set($block), Set($block)>>;
                HorizonWithDescendants(horizon_and_aggregate, i) ==
                    LET
                        horizon == horizon_and_aggregate[1]
                        aggregate == horizon_and_aggregate[2]
                        one_step_descendants == { block \in all_blocks : has_parent(block, single_node_state) /\ get_parent(block, single_node_state) \in horizon }
                    IN << one_step_descendants, aggregate \union one_step_descendants >>
            IN ApaFoldSeqLeft( HorizonWithDescendants, << { GenesisBlock }, { GenesisBlock } >>, MkSeq(MAX_SLOT, (* @type: Int => Int; *) LAMBDA i: i) )[2]
        /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP =
            LET \* @type: (<<Set($block), $block -> Set($block)>>, Int) => <<Set($block), $block -> Set($block)>>;
                HorizonWithDescendants(horizon_and_aggregate, i) ==
                    LET
                        horizon == horizon_and_aggregate[1]
                        aggregate == horizon_and_aggregate[2]
                        one_step_descendants == { block \in all_blocks : get_parent(block, single_node_state) \in horizon }
                        new_aggregate == [ block \in DOMAIN aggregate \union one_step_descendants |-> IF block \in one_step_descendants /\ has_parent(block, single_node_state) THEN { block } \union aggregate[get_parent(block, single_node_state)] ELSE aggregate[block] ]
                    IN << one_step_descendants, new_aggregate >>
                roots == { block \in all_blocks : ~has_parent(block, single_node_state) }
            IN ApaFoldSeqLeft(HorizonWithDescendants, << roots, [ root \in roots |-> { root } ] >>, MkSeq(MAX_SLOT, (* @type: Int => Int; *) LAMBDA i: i)) [2]
```

</details>

I benchmarked the strategies on a falsy invariants (producing finalizing votes for a checkpoint) and two different block views (a linear chain, and a single fork at genesis). All benchmark runs were fastest for `Precompute_Native`:

<details>

```
Benchmark 1: apalache-mc check --length=0 --discard-disabled --init=Init_SingleChain_Precompute_Naive    --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla
  Time (mean ± σ):     24.683 s ±  1.116 s    [User: 43.012 s, System: 1.274 s]
  Range (min … max):   23.462 s … 25.650 s    3 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: apalache-mc check --length=0 --discard-disabled --init=Init_SingleChain_Precompute_Fixpoint --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla
  Time (mean ± σ):     41.849 s ±  3.202 s    [User: 61.733 s, System: 1.326 s]
  Range (min … max):   39.981 s … 45.546 s    3 runs
 
  Warning: Ignoring non-zero exit code.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 3: apalache-mc check --length=0 --discard-disabled --init=Init_SingleChain_Precompute_Horizon  --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla
  Time (mean ± σ):     150.777 s ± 21.313 s    [User: 178.281 s, System: 1.859 s]
  Range (min … max):   135.268 s … 175.080 s    3 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  'apalache-mc check --length=0 --discard-disabled --init=Init_SingleChain_Precompute_Naive    --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla' ran
    1.70 ± 0.15 times faster than 'apalache-mc check --length=0 --discard-disabled --init=Init_SingleChain_Precompute_Fixpoint --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla'
    6.11 ± 0.91 times faster than 'apalache-mc check --length=0 --discard-disabled --init=Init_SingleChain_Precompute_Horizon  --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla'

Benchmark 1: apalache-mc check --length=0 --discard-disabled --init=Init_Forest_Precompute_Naive    --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla
  Time (mean ± σ):     46.743 s ±  2.176 s    [User: 76.008 s, System: 2.148 s]
  Range (min … max):   45.418 s … 49.254 s    3 runs
 
  Warning: Ignoring non-zero exit code.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 2: apalache-mc check --length=0 --discard-disabled --init=Init_Forest_Precompute_Fixpoint --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla
  Time (mean ± σ):     75.415 s ±  9.134 s    [User: 116.256 s, System: 2.541 s]
  Range (min … max):   68.793 s … 85.835 s    3 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 3: apalache-mc check --length=0 --discard-disabled --init=Init_Forest_Precompute_Horizon  --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla
  Time (mean ± σ):     526.378 s ± 120.217 s    [User: 577.057 s, System: 2.898 s]
  Range (min … max):   414.723 s … 653.633 s    3 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  'apalache-mc check --length=0 --discard-disabled --init=Init_Forest_Precompute_Naive    --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla' ran
    1.61 ± 0.21 times faster than 'apalache-mc check --length=0 --discard-disabled --init=Init_Forest_Precompute_Fixpoint --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla'
   11.26 ± 2.62 times faster than 'apalache-mc check --length=0 --discard-disabled --init=Init_Forest_Precompute_Horizon  --inv=FinalizedCheckpoint_Example MC_ffg_examples.tla'
```

</details>