### PR TITLE
Add fixed chains and examples

### DIFF
--- a/spec/MC_ffg.tla
+++ b/spec/MC_ffg.tla
@@ -16,7 +16,7 @@ Nodes == { "A", "B", "C", "D" }
 MAX_SLOT == 4
 
 \* Model-checking: Maximum number of votes in `view_votes`.
-MAX_VOTES == 6
+MAX_VOTES == 12
 
 \* ========== Dummy implementations of stubs ==========
 
@@ -73,12 +73,12 @@ IsValidCheckpoint(c, node_state) ==
        \/ \* Section 3.Checkpoints: "Importantly, the slot c for the checkpoint occurs after the slot B.p where the block was proposed"
           /\ c.block_slot >= 0
           /\ c.chkp_slot > c.block_slot
-          /\ c.chkp_slot <= MAX_SLOT
+          /\ c.chkp_slot <= MAX_SLOT+2
 
 \* @type: ($voteMessage, $commonNodeState) => Bool;
 IsValidVoteMessage(msg, node_state) ==
     /\ msg.slot >= 0
-    /\ msg.slot <= MAX_SLOT
+    /\ msg.slot <= MAX_SLOT+2
     \* A message can only reference checkpoints that have already happened
     \* QUESTION TO REVIEWERS: strict > ?
     /\ msg.slot >= msg.ffg_source.chkp_slot
@@ -161,12 +161,13 @@ Precompute ==
         /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP =
             [ descendant \in all_blocks |-> { ancestor \in all_blocks : is_ancestor_descendant_relationship(ancestor, descendant, single_node_state) } ]
         /\ LET
-                all_source_and_target_checkpoints ==
-                    { vote.message.ffg_source : vote \in single_node_state.view_votes } \union { vote.message.ffg_target : vote \in single_node_state.view_votes }
+                ffg_sources == { vote.message.ffg_source : vote \in single_node_state.view_votes }
+                ffg_targets == get_set_FFG_targets(single_node_state.view_votes)
+                all_source_and_target_checkpoints == ffg_sources \union ffg_targets
                 votes_in_support_assuming_justified_source ==
                     [ checkpoint \in all_source_and_target_checkpoints |-> VotesInSupportAssumingJustifiedSource(checkpoint, single_node_state) ]
                 initialTargetMap ==
-                    [ target \in get_set_FFG_targets(single_node_state.view_votes) |-> votes_in_support_assuming_justified_source[target] ]
+                    [ target \in ffg_targets |-> votes_in_support_assuming_justified_source[target] ]
            IN PRECOMPUTED__IS_JUSTIFIED_CHECKPOINT = AllJustifiedCheckpoints(initialTargetMap, single_node_state, MAX_SLOT)
 
 \* Start in some arbitrary state

--- a/spec/MC_ffg_examples.tla
+++ b/spec/MC_ffg_examples.tla
@@ -1,6 +1,6 @@
 ----------------------------- MODULE MC_ffg_examples -----------------------------
 (*
- * Falsy invariants to check reachability of certain states
+ * Fixed chains and falsy invariants to check reachability of certain states.
  *
  * Thomas Pani, 2024.
  *
@@ -8,6 +8,120 @@
  *)
 
 EXTENDS MC_ffg
+
+Init_SingleChain ==
+    LET
+        config == Gen(1)
+        id == Gen(1)
+        current_slot == MAX_SLOT
+        view_blocks == SetAsFun({
+            \* |   0    |    1    |    2    |    3    |    4    |
+            \* genesis <- BLOCK1 <- BLOCK2 <- BLOCK3 <- BLOCK4
+            <<"genesis", GenesisBlock>>,
+            <<"BLOCK1", [ parent_hash |-> "genesis", slot |-> 1, votes |-> {}, body |-> "BLOCK1" ] >>,
+            <<"BLOCK2", [ parent_hash |-> "BLOCK1", slot |-> 2, votes |-> {}, body |-> "BLOCK2" ] >>,
+            <<"BLOCK3", [ parent_hash |-> "BLOCK2", slot |-> 3, votes |-> {}, body |-> "BLOCK3" ] >>,
+            <<"BLOCK4", [ parent_hash |-> "BLOCK3", slot |-> 4, votes |-> {}, body |-> "BLOCK4" ] >>
+        })
+        view_votes == Gen(MAX_VOTES)
+        chava == Gen(1)
+    IN
+    /\ single_node_state = [ configuration |-> config, identity |-> id, current_slot |-> current_slot, view_blocks |-> view_blocks, view_votes |-> view_votes, chava |-> chava ]
+    /\ Precompute
+    /\ IsValidNodeState(single_node_state)
+
+\* Precompute for the single chain setup is correct
+Inv_SingleChain_PrecomputeOK ==
+    LET
+        b(hash) == single_node_state.view_blocks[hash]
+        bs(hashes) == { single_node_state.view_blocks[hash] : hash \in hashes }
+    IN
+    /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP = SetAsFun({
+        <<b("genesis"), bs({ "genesis" })>>,
+        <<b("BLOCK1"), bs({ "genesis", "BLOCK1" })>>,
+        <<b("BLOCK2"), bs({ "genesis", "BLOCK1", "BLOCK2" })>>,
+        <<b("BLOCK3"), bs({ "genesis", "BLOCK1", "BLOCK2", "BLOCK3" })>>,
+        <<b("BLOCK4"), bs({ "genesis", "BLOCK1", "BLOCK2", "BLOCK3", "BLOCK4" })>> })
+
+Init_Forest ==
+    LET
+        config == Gen(1)
+        id == Gen(1)
+        current_slot == MAX_SLOT
+        view_blocks == SetAsFun({
+            \* |   0    |    1    |    2    |    3    |    4    |
+            \* genesis <- BLOCK1 <- BLOCK2 <- BLOCK3 <- BLOCK4
+            \*       ^--- BLOCK5 <- BLOCK6 <- BLOCK7
+            \*
+            \* (... more blocks below)
+            <<"genesis", GenesisBlock>>,
+            <<"BLOCK1", [ parent_hash |-> "genesis", slot |-> 1, votes |-> {}, body |-> "BLOCK1" ] >>,
+            <<"BLOCK2", [ parent_hash |-> "BLOCK1", slot |-> 2, votes |-> {}, body |-> "BLOCK2" ] >>,
+            <<"BLOCK3", [ parent_hash |-> "BLOCK2", slot |-> 3, votes |-> {}, body |-> "BLOCK3" ] >>,
+            <<"BLOCK4", [ parent_hash |-> "BLOCK3", slot |-> 4, votes |-> {}, body |-> "BLOCK4" ] >>,
+            <<"BLOCK5", [ parent_hash |-> "genesis", slot |-> 1, votes |-> {}, body |-> "BLOCK5" ] >>,
+            <<"BLOCK6", [ parent_hash |-> "BLOCK5", slot |-> 2, votes |-> {}, body |-> "BLOCK6" ] >>,
+            <<"BLOCK7", [ parent_hash |-> "BLOCK6", slot |-> 3, votes |-> {}, body |-> "BLOCK7" ] >>,
+            \*
+            \* |   0    |    1    |    2    |    3    |    4    |
+            \*            BLOCK8
+            <<"BLOCK8", [ parent_hash |-> "not_here", slot |-> 1, votes |-> {}, body |-> "BLOCK8" ] >>,
+            \*
+            \* |   0    |    1    |    2    |    3    |    4    |
+            \*            BLOCK9 <- BLOCK10
+            <<"BLOCK9", [ parent_hash |-> "not_here", slot |-> 1, votes |-> {}, body |-> "BLOCK9" ] >>,
+            <<"BLOCK10", [ parent_hash |-> "BLOCK9", slot |-> 2, votes |-> {}, body |-> "BLOCK10" ] >>
+        })
+        view_votes == Gen(MAX_VOTES)
+        chava == Gen(1)
+    IN
+    /\ single_node_state = [ configuration |-> config, identity |-> id, current_slot |-> current_slot, view_blocks |-> view_blocks, view_votes |-> view_votes, chava |-> chava ]
+    /\ Precompute
+    /\ IsValidNodeState(single_node_state)
+
+\* Precompute for the forest chain setup is correct
+Inv_Forest_PrecomputeOK ==
+    LET
+        b(hash) == single_node_state.view_blocks[hash]
+        bs(hashes) == { single_node_state.view_blocks[hash] : hash \in hashes }
+    IN
+    /\ PRECOMPUTED__IS_ANCESTOR_DESCENDANT_RELATIONSHIP = SetAsFun({
+        <<b("genesis"), bs({ "genesis" })>>,
+        <<b("BLOCK1"), bs({ "genesis", "BLOCK1" })>>,
+        <<b("BLOCK2"), bs({ "genesis", "BLOCK1", "BLOCK2" })>>,
+        <<b("BLOCK3"), bs({ "genesis", "BLOCK1", "BLOCK2", "BLOCK3" })>>,
+        <<b("BLOCK4"), bs({ "genesis", "BLOCK1", "BLOCK2", "BLOCK3", "BLOCK4" })>>,
+        <<b("BLOCK5"), bs({ "genesis", "BLOCK5" })>>,
+        <<b("BLOCK6"), bs({ "genesis", "BLOCK5", "BLOCK6" })>>,
+        <<b("BLOCK7"), bs({ "genesis", "BLOCK5", "BLOCK6", "BLOCK7" })>>,
+        <<b("BLOCK8"), bs({ "BLOCK8" })>>,
+        <<b("BLOCK9"), bs({ "BLOCK9" })>>,
+        <<b("BLOCK10"), bs({ "BLOCK9", "BLOCK10" })>> })
+
+Init_ShortFork ==
+    LET
+        config == Gen(1)
+        id == Gen(1)
+        current_slot == MAX_SLOT
+        view_blocks == SetAsFun({
+            \* |   0    |    1    |
+            \* genesis <- BLOCK1
+            \*       ^---.
+            \*            BLOCK2
+            <<"genesis", GenesisBlock>>,
+            <<"BLOCK1", [ parent_hash |-> "genesis", slot |-> 1, votes |-> {}, body |-> "BLOCK1" ] >>,
+            <<"BLOCK2", [ parent_hash |-> "genesis", slot |-> 1, votes |-> {}, body |-> "BLOCK2" ] >>
+        })
+        view_votes == Gen(MAX_VOTES)
+        chava == Gen(1)
+    IN
+    /\ single_node_state = [ configuration |-> config, identity |-> id, current_slot |-> current_slot, view_blocks |-> view_blocks, view_votes |-> view_votes, chava |-> chava ]
+    /\ Precompute
+    /\ IsValidNodeState(single_node_state)
+
+\* ============================================================================
+\* Falsy invariants to check reachability of certain states.
+\* ============================================================================
 
 \* Find a complete chain BLOCK1 ->* genesis
 CompleteChain_Example ==
@@ -76,28 +190,46 @@ SurroundVoting_Example ==
 
 \* Find a validator linking to a checkpoint in the next slot (i.e., one that cast a valid FFG vote for checkpoint slots 3->4)
 ValidatorsLinkingNextSlot_Example ==
-    LET source_checkpoint == [ block_hash |-> "BLOCK1", block_slot |-> 2, chkp_slot |-> 3 ]
+    LET source_checkpoint == [ block_hash |-> "BLOCK1", block_slot |-> 1, chkp_slot |-> 2 ]
     IN get_validators_in_FFG_votes_linking_to_a_checkpoint_in_next_slot(source_checkpoint, single_node_state) = {}
 
 \* Find at least 3 justifying votes for checkpoint (assuming their sources are justified)
 VotesInSupport_Example ==
     LET
-        checkpoint == [ block_hash |-> "BLOCK1", block_slot |-> 2, chkp_slot |-> 3 ]
+        checkpoint == [ block_hash |-> "BLOCK1", block_slot |-> 1, chkp_slot |-> 2 ]
         setup == "BLOCK1" \in DOMAIN single_node_state.view_blocks
     IN setup => Cardinality(VotesInSupportAssumingJustifiedSource(checkpoint, single_node_state)) < 3
 
 \* Find justifying votes for a checkpoint
-JustifiedCheckpoint_Example ==
+JustifyingVotes_Example ==
     LET
-        checkpoint == [ block_hash |-> "BLOCK1", block_slot |-> 2, chkp_slot |-> 3 ]
+        checkpoint == [ block_hash |-> "BLOCK1", block_slot |-> 1, chkp_slot |-> 2 ]
         setup == "BLOCK1" \in DOMAIN single_node_state.view_blocks
     IN setup => ~is_justified_checkpoint(checkpoint, single_node_state)
 
 \* Find finalizing (and justifying) votes for a checkpoint
-FinalizedCheckpoint_Example ==
+FinalizingVotes_Example ==
     LET
-        checkpoint == [ block_hash |-> "BLOCK1", block_slot |-> 2, chkp_slot |-> 3 ]
+        checkpoint == [ block_hash |-> "BLOCK1", block_slot |-> 1, chkp_slot |-> 2 ]
         setup == "BLOCK1" \in DOMAIN single_node_state.view_blocks
     IN setup => ~is_finalized_checkpoint(checkpoint, single_node_state)
+
+\* Find a finalized checkpoint (in addition to the genesis checkpoint)
+FinalizedCheckpoint_Example ==
+    get_finalized_checkpoints(single_node_state) = { genesis_checkpoint(single_node_state) }
+
+\* Find at least two finalized blocks (in addition to the genesis block)
+FinalizedBlocks_Example ==
+    LET
+        finalized_checkpoints == get_finalized_checkpoints(single_node_state)
+        finalized_blocks == { get_block_from_hash(checkpoint.block_hash, single_node_state) : checkpoint \in finalized_checkpoints }
+    IN Cardinality(finalized_blocks) < 3
+
+\* Find at least two conflicting finalized blocks
+Finalized_And_Conflicting_Blocks_Example ==
+    LET
+        finalized_checkpoints == get_finalized_checkpoints(single_node_state)
+        finalized_blocks == { get_block_from_hash(checkpoint.block_hash, single_node_state) : checkpoint \in finalized_checkpoints }
+    IN \A block1, block2 \in finalized_blocks : ~are_conflicting(block1, block2, single_node_state)
 
 =============================================================================

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -12,4 +12,8 @@ check:
 clean:
 	rm -rf _apalache-out/
 
-.PHONY: check clean typecheck typecheck_all
+test:
+	apalache-mc check --init=Init_SingleChain --inv=Inv_SingleChain_PrecomputeOK --length=0 MC_ffg_examples.tla | grep EXITCODE
+	apalache-mc check --init=Init_Forest      --inv=Inv_Forest_PrecomputeOK      --length=0 MC_ffg_examples.tla | grep EXITCODE
+
+.PHONY: check clean test typecheck typecheck_all


### PR DESCRIPTION
Add 3 fixed chain setups:
- a single, linear chain
- a forest
- a single fork at genesis

Add a few more falsy invariants to produce examples.

Increase `MAX_VOTES` to 12 (needed to produce 2 finalized and conflicting blocks).

Also editing some checkpoints in the previous examples, s.t. the block actually appears in the fixed chain setups.