### PR TITLE
Refactoring the two-chain spec again

### DIFF
--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -77,7 +77,12 @@ IndInv ==
     /\ \A vote \in votes:
         /\ vote.ffg_vote \in ffg_votes
         /\ vote.validator \in VALIDATORS
-    /\ justified_checkpoints = JustifiedCheckpoints(votes)
+    /\ LET allCheckpoints == {Checkpoint(block, i): block \in all_blocks, i \in CheckpointSlots}
+       IN \E allJustifiedCheckpoints \in SUBSET allCheckpoints:
+        /\ justified_checkpoints' = allJustifiedCheckpoints
+        /\ \A c \in allJustifiedCheckpoints: IsJustified(c, votes', allJustifiedCheckpoints)
+        /\ \A c \in (allCheckpoints \ allJustifiedCheckpoints): ~IsJustified(c, votes', allJustifiedCheckpoints)
+    \*/\ justified_checkpoints = JustifiedCheckpoints(votes)
 
 IndInit ==
     \* We choose two different bounds for creating chain1 and chain2 with Gen.

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -43,4 +43,30 @@ VARIABLES
 
 INSTANCE ffg
 
+IndInit ==
+    /\ chain1 = Gen(MAX_BLOCK_SLOT + 1)
+    /\ \A block \in chain1: IsValidBlock(block)
+    /\ chain2 = Gen(MAX_BLOCK_SLOT + 1)
+    /\ \A block \in chain2: IsValidBlock(block)
+    /\ all_blocks = chain1 \union chain2
+    /\ GenesisBlock \in chain1
+    /\ GenesisBlock \in chain2
+    /\ chain1_tip_slot = 
+        LET blockWithLargestSlot == CHOOSE block \in chain1: \A otherBlock \in chain1: block.slot >= otherBlock.slot
+        IN blockWithLargestSlot.slot
+    /\ chain2_tip_slot = 
+        LET blockWithLargestSlot == CHOOSE block \in chain2: \A otherBlock \in chain2: block.slot >= otherBlock.slot
+        IN blockWithLargestSlot.slot
+    /\ chain1_next_idx = Cardinality(chain1) + 1
+    /\ chain2_next_idx = Cardinality(chain2) + 1
+    /\ chain2_forked = (chain1 /= chain2)
+    /\ ffg_votes = Gen(5) \* must be >= 4 to create two finalized conflicting blocks 
+    /\ \A ffgVote \in ffg_votes: IsValidFFGVote(ffgVote)
+    /\ votes = Gen(12) \* Must be >= 12 to observe disagreement
+    /\ \A vote \in votes:
+        /\ vote.ffg_vote \in ffg_votes
+        /\ vote.validator \in VALIDATORS
+    /\ justified_checkpoints = JustifiedCheckpoints
+
+
 =============================================================================

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -45,7 +45,7 @@ INSTANCE ffg
 Abs(x) == IF x >= 0 THEN x ELSE -x
 
 IndInv ==
-    /\ chain2_fork_block_number \in -MAX_BLOCK_BODY..0
+    /\ -MAX_BLOCK_BODY <= chain2_fork_block_number /\ chain2_fork_block_number <= 0
     /\ all_blocks = chain1 \union chain2
     \* chain1_tip is the maximum block in chain 1
     /\ \A b \in chain1: b.body <= chain1_tip.body

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -67,6 +67,8 @@ IndInv ==
     \* there are no gaps in the block numbers (some of them are negative)
     /\ \A i \in 0..MAX_BLOCK_BODY:
         i <= Abs(chain2_tip.body) => \E b \in chain2: Abs(b.body) = i
+    \* chain2_fork_block_number has to be in chain2
+    /\ \E b \in chain2: b.body = chain2_fork_block_number
     \* when there is no fork, the tips coincide
     /\ ~IsForked => chain2_tip = chain1_tip
     /\ GenesisBlock \in chain1

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -46,6 +46,8 @@ Abs(x) == IF x >= 0 THEN x ELSE -x
 IndInv ==
     /\ chain2_fork_block_number \in -1..MAX_BLOCK_BODY
     /\ all_blocks = chain1 \union chain2
+    \* chain1_tip is the maximum block in chain 1
+    /\ \A b \in chain1: b.body <= chain1_tip.body
     \* block numbers on chain 1 simply go from 0 to chain1_tip.body
     /\ \A b1, b2 \in chain1:
         /\ b1.body >= 0 /\ b1.body <= chain1_tip.body
@@ -53,7 +55,9 @@ IndInv ==
     \* there are no gaps in the block numbers
     /\ \A i \in 0..MAX_BLOCK_BODY:
         i <= chain1_tip.body => \E b \in chain1: b.body = i
-    \* block numbers of in chain 1 go from 0 to (chain2_for_block_number - 1),
+    \* chain2_tip is the maximum block in chain 2
+    /\ \A b \in chain2: Abs(b.body) <= Abs(chain2_tip.body)
+    \* block numbers on chain 2 go from 0 to (chain2_for_block_number - 1),
     \* then -chain2_fork_block_number to chain2_tip.body
     /\ \A b1, b2 \in chain2:
         /\ (b1.body >= 0) => (b1.body < chain2_fork_block_number) \/ ~IsForked

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -87,7 +87,7 @@ IndInit ==
     /\ ffg_votes = Gen(5) \* must be >= 4 to observe disagreement
     /\ votes = Gen(12)    \* must be >= 12 to observe disagreement
     /\ \E fork_number \in Int:
-        /\ fork_number \in 0..MAX_BLOCK_BODY
+        /\ fork_number \in -MAX_BLOCK_BODY..0
         /\ chain2_fork_block_number = fork_number
     /\ IndInv
 

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -58,11 +58,12 @@ IndInv ==
         i <= chain1_tip.body => \E b \in chain1: b.body = i
     \* chain2_tip is the maximum block in chain 2
     /\ \A b \in chain2: Abs(b.body) <= Abs(chain2_tip.body)
-    \* block numbers on chain 2 go from 0 to (chain2_for_block_number - 1),
-    \* then chain2_tip.body to chain2_fork_block_number
+    \* Positive block numbers on chain 2 go from 0 to -chain2_fork_block_number - 1, if there was a fork.
+    \* Negative block numbers on chain 2 go from -chain2_fork_block_number to chain2_tip.body, if there was a fork.
+    \* If there was no fork, all block numbers on chain 2 are non-negative.
     /\ \A b1, b2 \in chain2:
         /\ (b1.body >= 0) => (b1.body < -chain2_fork_block_number) \/ ~IsForked
-        /\ (b1.body < 0)  => (chain2_tip.body <= chain2_fork_block_number)
+        /\ (b1.body < 0)  => (b1.body <= chain2_fork_block_number) /\ IsForked
         /\ (Abs(b1.body) >= Abs(b2.body)) <=> (b1.slot >= b2.slot)
     \* there are no gaps in the block numbers (some of them are negative)
     /\ \A i \in 0..MAX_BLOCK_BODY:

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -1,0 +1,40 @@
+----------------------------- MODULE MC_ffg -----------------------------
+
+EXTENDS FiniteSets
+
+\* @type: Int;
+MAX_BLOCK_SLOT == 5
+
+\* @type: Set(Str);
+BLOCK_BODIES == {"A", "B", "C", "D", "E"}
+
+\* @type: Set(Str);
+VALIDATORS == {"V1", "V2", "V3", "V4"}
+
+N == 4
+
+VARIABLES
+    \* @type: Set($block);
+    blocks,
+    \* @type: Int -> $block;
+    chain1,
+    \* @type: Int;
+    chain1_tip_index,
+    \* @type: Int -> $block;
+    chain2,
+    \* @type: Int;
+    chain2_tip_index,
+    \* @type: Bool;
+    forked,
+    \* @type: $block -> Set($block);
+    ancestors,
+    \* @type: Set($ffgVote);
+    ffg_votes,
+    \* @type: Set($vote);
+    votes,
+    \* @type: Set($checkpoint);
+    justified_checkpoints
+
+INSTANCE ffg
+
+=============================================================================

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -74,7 +74,6 @@ IndInit ==
     /\ \A vote \in votes:
         /\ vote.ffg_vote \in ffg_votes
         /\ vote.validator \in VALIDATORS
-    /\ justified_checkpoints = JustifiedCheckpoints
-
+    /\ justified_checkpoints = JustifiedCheckpoints(votes)
 
 =============================================================================

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -5,8 +5,12 @@ EXTENDS FiniteSets
 \* @type: Int;
 MAX_BLOCK_SLOT == 5
 
-\* @type: Set(Str);
-BLOCK_BODIES == {"A", "B", "C", "D", "E"}
+\* @type: Seq(Int);
+BLOCK_BODIES1 == <<0, 1, 2, 3, 4, 5>>
+\* @type: Seq(Int);
+BLOCK_BODIES2 == <<0, 11, 12, 13, 14, 15>>
+\* @type: Set(Int);
+ALL_BLOCK_BODIES == { 0, 1, 2, 3, 4, 5, 11, 12, 13, 14, 15 }
 
 \* @type: Set(Str);
 VALIDATORS == {"V1", "V2", "V3", "V4"}
@@ -20,10 +24,16 @@ VARIABLES
     chain1,
     \* @type: Int;
     chain1_tip_slot,
+    \* @type: Int;
+    chain1_next_idx,
     \* @type: Set($block);
     chain2,
     \* @type: Int;
     chain2_tip_slot,
+    \* @type: Int;
+    chain2_next_idx,
+    \* @type: Bool;
+    chain2_forked,
     \* @type: Set($ffgVote);
     ffg_votes,
     \* @type: Set($vote);

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -7,6 +7,8 @@ MAX_BLOCK_SLOT == 5
 
 \* @type: Seq(Int);
 BLOCK_BODIES1 == <<0, 1, 2, 3, 4, 5>>
+\* @type: Set(Int);
+BLOCK_BODIES1_SET == {0, 1, 2, 3, 4, 5}
 \* @type: Seq(Int);
 BLOCK_BODIES2 == <<0, 11, 12, 13, 14, 15>>
 \* @type: Set(Int);
@@ -43,20 +45,33 @@ VARIABLES
 
 INSTANCE ffg
 
+\* We avoid creating chain1 and chain2 with Gen. See Apalache issue #2973.
 IndInit ==
-    /\ chain1 = Gen(MAX_BLOCK_SLOT + 1)
-    /\ \A block \in chain1: IsValidBlock(block)
-    /\ chain2 = Gen(MAX_BLOCK_SLOT + 1)
-    /\ \A block \in chain2: IsValidBlock(block)
+    /\ \E chain1Len \in DOMAIN BLOCK_BODIES1: \* if we know how long chain1 is, we know the exact sequence of block bodies
+        /\ chain1 \in SUBSET [slot: BlockSlots, body: BLOCK_BODIES1_SET]
+        \* Below, B gives us at least one block per body, A additionally constrains it to _exactly_ one block per body:
+        /\ Cardinality(chain1) = chain1Len \* A
+        /\ \A i \in DOMAIN BLOCK_BODIES1: (i <= chain1Len) => \E block \in chain1: block.body = BLOCK_BODIES1[i] \* B
+        \* well-ordered blocks
+        /\ \A b1,b2 \in chain1: b1.body < b2.body => b1.slot < b2.slot
+    /\ \E chain2Len, prefixLen \in DOMAIN BLOCK_BODIES1: \* if we know how long chain2 is, we know the _relative_ sequence of block bodies
+        /\ prefixLen <= chain2Len
+        /\ chain2 \in SUBSET [slot: BlockSlots, body: ALL_BLOCK_BODIES]
+        /\ Cardinality(chain1) = chain2Len
+        /\ \A i \in DOMAIN BLOCK_BODIES1: 
+            \* shared prefix with chain1
+            /\ (i <= prefixLen) => \E block \in (chain2 \intersect chain1): block.body = BLOCK_BODIES1[i]
+            /\ (prefixLen < i /\ i <= chain2Len) => \E block \in chain2: block.body = BLOCK_BODIES2[i]
+        /\ \A b1,b2 \in chain2: b1.body < b2.body => b1.slot < b2.slot
     /\ all_blocks = chain1 \union chain2
     /\ GenesisBlock \in chain1
     /\ GenesisBlock \in chain2
-    /\ chain1_tip_slot = 
-        LET blockWithLargestSlot == CHOOSE block \in chain1: \A otherBlock \in chain1: block.slot >= otherBlock.slot
-        IN blockWithLargestSlot.slot
-    /\ chain2_tip_slot = 
-        LET blockWithLargestSlot == CHOOSE block \in chain2: \A otherBlock \in chain2: block.slot >= otherBlock.slot
-        IN blockWithLargestSlot.slot
+    /\ \E blockWithLargestSlot \in chain1: 
+        /\ chain1_tip_slot = blockWithLargestSlot.slot
+        /\ \A otherBlock \in chain1: blockWithLargestSlot.slot >= otherBlock.slot
+    /\ \E blockWithLargestSlot \in chain2: 
+        /\ chain2_tip_slot = blockWithLargestSlot.slot
+        /\ \A otherBlock \in chain2: blockWithLargestSlot.slot >= otherBlock.slot
     /\ chain1_next_idx = Cardinality(chain1) + 1
     /\ chain2_next_idx = Cardinality(chain2) + 1
     /\ chain2_forked = (chain1 /= chain2)

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -72,6 +72,9 @@ IndInv ==
     /\ \E b \in chain2: b.body = chain2_fork_block_number
     \* when there is no fork, the tips coincide
     /\ ~IsForked => chain2_tip = chain1_tip
+    \* before the fork point, chain2 and chain1 coincide
+    /\ \A b \in chain2:
+        b.body >= 0 => b \in chain1
     /\ GenesisBlock \in chain1
     /\ GenesisBlock \in chain2
     /\ \A ffgVote \in ffg_votes: IsValidFFGVote(ffgVote)

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -15,19 +15,15 @@ N == 4
 
 VARIABLES
     \* @type: Set($block);
-    blocks,
-    \* @type: Int -> $block;
+    all_blocks,
+    \* @type: Set($block);
     chain1,
     \* @type: Int;
-    chain1_tip_index,
-    \* @type: Int -> $block;
+    chain1_tip_slot,
+    \* @type: Set($block);
     chain2,
     \* @type: Int;
-    chain2_tip_index,
-    \* @type: Bool;
-    forked,
-    \* @type: $block -> Set($block);
-    ancestors,
+    chain2_tip_slot,
     \* @type: Set($ffgVote);
     ffg_votes,
     \* @type: Set($vote);

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -28,7 +28,7 @@ VARIABLES
     \* the latest block on chain 2
     \* @type: $block;
     chain2_tip,
-    \* If chain2_fork_block_number is not -1,
+    \* If chain2_fork_block_number is not equal to 0,
     \* then chain2 is a fork of chain1 starting at chain2_fork_block_number
     \* @type: Int;
     chain2_fork_block_number,
@@ -38,6 +38,7 @@ VARIABLES
     votes,
     \* @type: Set($checkpoint);
     justified_checkpoints
+
 
 INSTANCE ffg
 

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -45,10 +45,7 @@ VARIABLES
 
 INSTANCE ffg
 
-IndInit ==
-    \* We avoid creating chain1 and chain2 with Gen. See Apalache issue #2973.
-    /\ chain1 \in SUBSET [slot: BlockSlots, body: BLOCK_BODIES1_SET]
-    /\ chain2 \in SUBSET [slot: BlockSlots, body: ALL_BLOCK_BODIES]
+IndInv ==
     /\ all_blocks = chain1 \union chain2
     \* There are no two blocks on chain1 and chain2 with the same slot
     /\ \A b1, b2 \in chain1: b1 /= b2 => b1.slot /= b2.slot
@@ -68,12 +65,19 @@ IndInit ==
     /\ chain1_next_idx = Cardinality(chain1) + 1
     /\ chain2_next_idx = Cardinality(chain2) + 1
     /\ chain2_forked = (chain1 /= chain2)
-    /\ ffg_votes = Gen(5) \* must be >= 4 to create two finalized conflicting blocks 
     /\ \A ffgVote \in ffg_votes: IsValidFFGVote(ffgVote)
-    /\ votes = Gen(12) \* Must be >= 12 to observe disagreement
     /\ \A vote \in votes:
         /\ vote.ffg_vote \in ffg_votes
         /\ vote.validator \in VALIDATORS
     /\ justified_checkpoints = JustifiedCheckpoints(votes)
+
+IndInit ==
+    \* We choose two different bounds for creating chain1 and chain2 with Gen.
+    \* See Apalache issue #2973.
+    /\ chain1 = Gen(3)
+    /\ chain2 = Gen(4)
+    /\ ffg_votes = Gen(5) \* must be >= 4 to observe disagreement
+    /\ votes = Gen(12)    \* must be >= 12 to observe disagreement
+    /\ IndInv
 
 =============================================================================

--- a/spec-abstract-noclosure/MC_ffg.tla
+++ b/spec-abstract-noclosure/MC_ffg.tla
@@ -44,7 +44,7 @@ INSTANCE ffg
 Abs(x) == IF x >= 0 THEN x ELSE -x
 
 IndInv ==
-    /\ chain2_fork_block_number \in 0..MAX_BLOCK_BODY
+    /\ chain2_fork_block_number \in -MAX_BLOCK_BODY..0
     /\ all_blocks = chain1 \union chain2
     \* chain1_tip is the maximum block in chain 1
     /\ \A b \in chain1: b.body <= chain1_tip.body

--- a/spec-abstract-noclosure/MC_ffg_b1_ffg5_v12.tla
+++ b/spec-abstract-noclosure/MC_ffg_b1_ffg5_v12.tla
@@ -1,4 +1,4 @@
-------------------------- MODULE MC_ffg_b3_ffg5_v12 ----------------------------
+------------------------- MODULE MC_ffg_b1_ffg5_v12 ----------------------------
 
 EXTENDS FiniteSets
 
@@ -7,7 +7,7 @@ EXTENDS FiniteSets
 \* @type: Int;
 MAX_BLOCK_SLOT == 3
 \* @type: Int;
-MAX_BLOCK_BODY == 3
+MAX_BLOCK_BODY == 1
 
 \* @type: Set(Str);
 VALIDATORS == {"V1", "V2", "V3", "V4"}

--- a/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
@@ -11,6 +11,7 @@ MAX_BLOCK_BODY == 3
 VALIDATORS == {"V1", "V2", "V3", "V4"}
 
 N == 4
+T == 1
 
 VARIABLES
     \* the set of all_blocks

--- a/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
@@ -48,6 +48,7 @@ INSTANCE ffg_inductive
 IndInit ==
     \* We choose two different bounds for creating chain1 and chain2 with Gen.
     \* See Apalache issue #2973.
+    /\ all_blocks = Gen(5)
     /\ chain1 = Gen(3)
     /\ chain1_tip \in chain1
     /\ chain2 = Gen(4)
@@ -58,6 +59,7 @@ IndInit ==
         /\ fork_number \in -MAX_BLOCK_BODY..0
         /\ chain2_fork_block_number = fork_number
     /\ checkpoints = Gen(5)
+    /\ justified_checkpoints = Gen(5)
     /\ IndInv
 
 =============================================================================

--- a/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
@@ -1,0 +1,59 @@
+----------------------- MODULE MC_ffg_b3_ffg10_v20 -----------------------------
+
+EXTENDS FiniteSets
+
+\* @type: Int;
+MAX_BLOCK_SLOT == 5
+\* @type: Int;
+MAX_BLOCK_BODY == 3
+
+\* @type: Set(Str);
+VALIDATORS == {"V1", "V2", "V3", "V4"}
+
+N == 4
+
+VARIABLES
+    \* the set of all_blocks
+    \* @type: Set($block);
+    all_blocks,
+    \* the set of blocks on chain 1
+    \* @type: Set($block);
+    chain1,
+    \* the latest block on chain 1
+    \* @type: $block;
+    chain1_tip,
+    \* the set of blocks on chain 2
+    \* @type: Set($block);
+    chain2,
+    \* the latest block on chain 2
+    \* @type: $block;
+    chain2_tip,
+    \* If chain2_fork_block_number is not equal to 0,
+    \* then chain2 is a fork of chain1 starting at chain2_fork_block_number
+    \* @type: Int;
+    chain2_fork_block_number,
+    \* @type: Set($ffgVote);
+    ffg_votes,
+    \* @type: Set($vote);
+    votes,
+    \* @type: Set($checkpoint);
+    justified_checkpoints
+
+
+INSTANCE ffg_inductive
+
+IndInit ==
+    \* We choose two different bounds for creating chain1 and chain2 with Gen.
+    \* See Apalache issue #2973.
+    /\ chain1 = Gen(3)
+    /\ chain1_tip \in chain1
+    /\ chain2 = Gen(4)
+    /\ chain2_tip \in chain2
+    /\ ffg_votes = Gen(10) \* must be >= 4 to observe disagreement
+    /\ votes = Gen(20)    \* must be >= 12 to observe disagreement
+    /\ \E fork_number \in Int:
+        /\ fork_number \in -MAX_BLOCK_BODY..0
+        /\ chain2_fork_block_number = fork_number
+    /\ IndInv
+
+=============================================================================

--- a/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
@@ -37,9 +37,6 @@ VARIABLES
     ffg_votes,
     \* @type: Set($vote);
     votes,
-    \* The set of the checkpoints that were announced so far.
-    \* @type: Set($checkpoint);
-    checkpoints,
     \* @type: Set($checkpoint);
     justified_checkpoints
 
@@ -59,7 +56,6 @@ IndInit ==
     /\ \E fork_number \in Int:
         /\ fork_number \in -MAX_BLOCK_BODY..0
         /\ chain2_fork_block_number = fork_number
-    /\ checkpoints = Gen(5)
     /\ justified_checkpoints = Gen(5)
     /\ IndInv
 

--- a/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b3_ffg10_v20.tla
@@ -36,6 +36,9 @@ VARIABLES
     ffg_votes,
     \* @type: Set($vote);
     votes,
+    \* The set of the checkpoints that were announced so far.
+    \* @type: Set($checkpoint);
+    checkpoints,
     \* @type: Set($checkpoint);
     justified_checkpoints
 
@@ -54,6 +57,7 @@ IndInit ==
     /\ \E fork_number \in Int:
         /\ fork_number \in -MAX_BLOCK_BODY..0
         /\ chain2_fork_block_number = fork_number
+    /\ checkpoints = Gen(5)
     /\ IndInv
 
 =============================================================================

--- a/spec-abstract-noclosure/MC_ffg_b3_ffg5_v12.tla
+++ b/spec-abstract-noclosure/MC_ffg_b3_ffg5_v12.tla
@@ -11,6 +11,7 @@ MAX_BLOCK_BODY == 3
 VALIDATORS == {"V1", "V2", "V3", "V4"}
 
 N == 4
+T == 1
 
 VARIABLES
     \* the set of all_blocks

--- a/spec-abstract-noclosure/MC_ffg_b3_ffg5_v12.tla
+++ b/spec-abstract-noclosure/MC_ffg_b3_ffg5_v12.tla
@@ -1,0 +1,59 @@
+------------------------- MODULE MC_ffg_b3_ffg5_v12 ----------------------------
+
+EXTENDS FiniteSets
+
+\* @type: Int;
+MAX_BLOCK_SLOT == 5
+\* @type: Int;
+MAX_BLOCK_BODY == 3
+
+\* @type: Set(Str);
+VALIDATORS == {"V1", "V2", "V3", "V4"}
+
+N == 4
+
+VARIABLES
+    \* the set of all_blocks
+    \* @type: Set($block);
+    all_blocks,
+    \* the set of blocks on chain 1
+    \* @type: Set($block);
+    chain1,
+    \* the latest block on chain 1
+    \* @type: $block;
+    chain1_tip,
+    \* the set of blocks on chain 2
+    \* @type: Set($block);
+    chain2,
+    \* the latest block on chain 2
+    \* @type: $block;
+    chain2_tip,
+    \* If chain2_fork_block_number is not equal to 0,
+    \* then chain2 is a fork of chain1 starting at chain2_fork_block_number
+    \* @type: Int;
+    chain2_fork_block_number,
+    \* @type: Set($ffgVote);
+    ffg_votes,
+    \* @type: Set($vote);
+    votes,
+    \* @type: Set($checkpoint);
+    justified_checkpoints
+
+
+INSTANCE ffg_inductive
+
+IndInit ==
+    \* We choose two different bounds for creating chain1 and chain2 with Gen.
+    \* See Apalache issue #2973.
+    /\ chain1 = Gen(3)
+    /\ chain1_tip \in chain1
+    /\ chain2 = Gen(4)
+    /\ chain2_tip \in chain2
+    /\ ffg_votes = Gen(5) \* must be >= 4 to observe disagreement
+    /\ votes = Gen(12)    \* must be >= 12 to observe disagreement
+    /\ \E fork_number \in Int:
+        /\ fork_number \in -MAX_BLOCK_BODY..0
+        /\ chain2_fork_block_number = fork_number
+    /\ IndInv
+
+=============================================================================

--- a/spec-abstract-noclosure/MC_ffg_b3_ffg5_v12.tla
+++ b/spec-abstract-noclosure/MC_ffg_b3_ffg5_v12.tla
@@ -36,6 +36,9 @@ VARIABLES
     ffg_votes,
     \* @type: Set($vote);
     votes,
+    \* The set of the checkpoints that were announced so far.
+    \* @type: Set($checkpoint);
+    checkpoints,
     \* @type: Set($checkpoint);
     justified_checkpoints
 
@@ -54,6 +57,7 @@ IndInit ==
     /\ \E fork_number \in Int:
         /\ fork_number \in -MAX_BLOCK_BODY..0
         /\ chain2_fork_block_number = fork_number
+    /\ checkpoints = Gen(5)
     /\ IndInv
 
 =============================================================================

--- a/spec-abstract-noclosure/MC_ffg_b3_ffg5_v12.tla
+++ b/spec-abstract-noclosure/MC_ffg_b3_ffg5_v12.tla
@@ -48,6 +48,7 @@ INSTANCE ffg_inductive
 IndInit ==
     \* We choose two different bounds for creating chain1 and chain2 with Gen.
     \* See Apalache issue #2973.
+    /\ all_blocks = Gen(6)
     /\ chain1 = Gen(3)
     /\ chain1_tip \in chain1
     /\ chain2 = Gen(4)
@@ -58,6 +59,7 @@ IndInit ==
         /\ fork_number \in -MAX_BLOCK_BODY..0
         /\ chain2_fork_block_number = fork_number
     /\ checkpoints = Gen(5)
+    /\ justified_checkpoints = Gen(5)
     /\ IndInv
 
 =============================================================================

--- a/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
@@ -11,6 +11,7 @@ MAX_BLOCK_BODY == 3
 VALIDATORS == {"V1", "V2", "V3", "V4"}
 
 N == 4
+T == 1
 
 VARIABLES
     \* the set of all_blocks

--- a/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
@@ -48,6 +48,7 @@ INSTANCE ffg_inductive
 IndInit ==
     \* We choose two different bounds for creating chain1 and chain2 with Gen.
     \* See Apalache issue #2973.
+    /\ all_blocks = Gen(10)
     /\ chain1 = Gen(5)
     /\ chain1_tip \in chain1
     /\ chain2 = Gen(6)
@@ -57,7 +58,8 @@ IndInit ==
     /\ \E fork_number \in Int:
         /\ fork_number \in -MAX_BLOCK_BODY..0
         /\ chain2_fork_block_number = fork_number
-    /\ checkpoints = Gen(5)
+    /\ checkpoints = Gen(10)
+    /\ justified_checkpoints = Gen(10)
     /\ IndInv
 
 =============================================================================

--- a/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
@@ -37,9 +37,6 @@ VARIABLES
     ffg_votes,
     \* @type: Set($vote);
     votes,
-    \* The set of the checkpoints that were announced so far.
-    \* @type: Set($checkpoint);
-    checkpoints,
     \* @type: Set($checkpoint);
     justified_checkpoints
 
@@ -59,7 +56,6 @@ IndInit ==
     /\ \E fork_number \in Int:
         /\ fork_number \in -MAX_BLOCK_BODY..0
         /\ chain2_fork_block_number = fork_number
-    /\ checkpoints = Gen(10)
     /\ justified_checkpoints = Gen(10)
     /\ IndInv
 

--- a/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
@@ -1,0 +1,59 @@
+----------------------- MODULE MC_ffg_b5_ffg10_v20 -----------------------------
+
+EXTENDS FiniteSets
+
+\* @type: Int;
+MAX_BLOCK_SLOT == 5
+\* @type: Int;
+MAX_BLOCK_BODY == 3
+
+\* @type: Set(Str);
+VALIDATORS == {"V1", "V2", "V3", "V4"}
+
+N == 4
+
+VARIABLES
+    \* the set of all_blocks
+    \* @type: Set($block);
+    all_blocks,
+    \* the set of blocks on chain 1
+    \* @type: Set($block);
+    chain1,
+    \* the latest block on chain 1
+    \* @type: $block;
+    chain1_tip,
+    \* the set of blocks on chain 2
+    \* @type: Set($block);
+    chain2,
+    \* the latest block on chain 2
+    \* @type: $block;
+    chain2_tip,
+    \* If chain2_fork_block_number is not equal to 0,
+    \* then chain2 is a fork of chain1 starting at chain2_fork_block_number
+    \* @type: Int;
+    chain2_fork_block_number,
+    \* @type: Set($ffgVote);
+    ffg_votes,
+    \* @type: Set($vote);
+    votes,
+    \* @type: Set($checkpoint);
+    justified_checkpoints
+
+
+INSTANCE ffg_inductive
+
+IndInit ==
+    \* We choose two different bounds for creating chain1 and chain2 with Gen.
+    \* See Apalache issue #2973.
+    /\ chain1 = Gen(5)
+    /\ chain1_tip \in chain1
+    /\ chain2 = Gen(6)
+    /\ chain2_tip \in chain2
+    /\ ffg_votes = Gen(10) \* must be >= 4 to observe disagreement
+    /\ votes = Gen(20)    \* must be >= 12 to observe disagreement
+    /\ \E fork_number \in Int:
+        /\ fork_number \in -MAX_BLOCK_BODY..0
+        /\ chain2_fork_block_number = fork_number
+    /\ IndInv
+
+=============================================================================

--- a/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
+++ b/spec-abstract-noclosure/MC_ffg_b5_ffg10_v20.tla
@@ -36,6 +36,9 @@ VARIABLES
     ffg_votes,
     \* @type: Set($vote);
     votes,
+    \* The set of the checkpoints that were announced so far.
+    \* @type: Set($checkpoint);
+    checkpoints,
     \* @type: Set($checkpoint);
     justified_checkpoints
 
@@ -54,6 +57,7 @@ IndInit ==
     /\ \E fork_number \in Int:
         /\ fork_number \in -MAX_BLOCK_BODY..0
         /\ chain2_fork_block_number = fork_number
+    /\ checkpoints = Gen(5)
     /\ IndInv
 
 =============================================================================

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -242,8 +242,8 @@ AccountableSafety ==
 
 Init == 
     /\ all_blocks = { GenesisBlock }
-    /\ chain1_tip = [ slot |-> 0, body |-> 0 ]
-    /\ chain2_tip = [ slot |-> 0, body |-> 0 ]
+    /\ chain1_tip = GenesisBlock
+    /\ chain2_tip = GenesisBlock
     /\ chain1 = { GenesisBlock }
     /\ chain2 = { GenesisBlock }
     /\ chain2_fork_block_number = 0

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -116,8 +116,8 @@ IsValidFFGVote(vote) ==
     /\ vote.source[2] < vote.target[2]
     /\ IsLeftAncestorOfRight(vote.source[1], vote.target[1])
     \* similar to has_block_hash
-    /\ vote.source \in all_blocks
-    /\ vote.target \in all_blocks
+    /\ \E b \in all_blocks: vote.source[1].body = b.body
+    /\ \E b \in all_blocks: vote.target[1].body = b.body
 
 \* @type: ($checkpoint, Set($vote), Set($checkpoint)) => Bool;
 IsJustified(checkpoint, viewVotes, fixpoint) == 

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -1,0 +1,213 @@
+----------------------------- MODULE ffg -----------------------------
+(*
+ * TODO
+ *
+ * Thomas Pani, 2024.
+ *
+ * Subject to Apache 2.0. See `LICENSE.md`.
+ *)
+
+EXTENDS FiniteSets, Integers, TLC, typedefs
+
+CONSTANT 
+    \* @type: Int;
+    MAX_BLOCK_SLOT,
+    \* @type: Set(Str);
+    BLOCK_BODIES,
+    \* @type: Set(Str);
+    VALIDATORS,
+    \* N = Cardinality(VALIDATORS)
+    \* @type: Int;
+    N
+
+BlockSlots == 0..MAX_BLOCK_SLOT
+CheckpointSlots == 0..(MAX_BLOCK_SLOT+2)
+
+VARIABLES
+    \* @type: Set($block);
+    blocks,
+    \* @type: Int -> $block;
+    chain1,
+    \* @type: Int;
+    chain1_tip_index,
+    \* @type: Int -> $block;
+    chain2,
+    \* @type: Int;
+    chain2_tip_index,
+    \* @type: Bool;
+    forked,
+    \* @type: $block -> Set($block);
+    ancestors,
+    \* @type: Set($ffgVote);
+    ffg_votes,
+    \* @type: Set($vote);
+    votes,
+    \* @type: Set($checkpoint);
+    justified_checkpoints
+
+\* @type: (Int, Str) => $block;
+Block(slot, body) == [ slot |-> slot, body |-> body ]
+\* @type: ($block, Int) => $checkpoint;
+Checkpoint(block, checkpoint_slot) == <<block, checkpoint_slot>>
+\* @type: (Str, $ffgVote) => $vote;
+Vote(validator, ffgVote) == [ validator |-> validator, ffg_vote |-> ffgVote ]
+
+GenesisBlockBody == "genesis"
+GenesisBlock == Block(0, GenesisBlockBody)
+GenesisCheckpoint == Checkpoint(GenesisBlock, 0)
+
+\* @type: ($block, $block) => Bool;
+AreConflictingBlocks(b1, b2) ==
+    /\ b1 \notin ancestors[b2]
+    /\ b2 \notin ancestors[b1]
+
+\* @type: ($block) => Bool;
+IsValidBlock(block) ==
+    /\ block.body \in (BLOCK_BODIES \union {GenesisBlockBody})
+    /\ block.slot \in BlockSlots
+
+\* @type: ($checkpoint) => Bool;
+IsValidCheckpoint(checkpoint) == 
+    LET block == checkpoint[1]
+        checkpoint_slot == checkpoint[2]
+    IN
+        /\ IsValidBlock(block)
+        /\\/ checkpoint = GenesisCheckpoint
+            \* Section 3.Checkpoints: "Importantly, the slot c for the checkpoint occurs after the slot B.p where the block was proposed"
+          \//\ checkpoint_slot \in CheckpointSlots
+            /\ checkpoint_slot > block.slot
+
+\* @type: ($ffgVote) => Bool;
+IsValidFFGVote(vote) ==
+    /\ IsValidCheckpoint(vote.source)
+    /\ IsValidCheckpoint(vote.target)
+    /\ vote.source[2] < vote.target[2]
+    /\ vote.source[1] \in ancestors[vote.target[1]]
+
+\* @type: ($checkpoint, Set($vote), Set($checkpoint)) => Bool;
+IsJustified(checkpoint, viewVotes, fixpoint) == 
+    \/ checkpoint = GenesisCheckpoint
+    \/ LET validatorsWhoCastJustifyingVote == { 
+        v \in VALIDATORS: \E justifyingVote \in viewVotes:
+            /\ justifyingVote.validator = v
+            /\ LET ffgVote == justifyingVote.ffg_vote IN
+                \* L6:
+                /\ ffgVote.source \in fixpoint
+                \* L7:
+                /\ checkpoint[1] \in ancestors[ffgVote.target[1]]
+                /\ ffgVote.source[1] \in ancestors[checkpoint[1]]
+                \* L8:
+                /\ ffgVote.target[2] = checkpoint[2] }    
+        IN 3 * Cardinality(validatorsWhoCastJustifyingVote) >= 2 * N
+
+\* @type: ($checkpoint, Set($vote), Set($checkpoint)) => Bool;
+IsFinalized(checkpoint, viewVotes, justifiedCheckpoints) ==
+    \/ checkpoint = GenesisCheckpoint
+    \/ /\ checkpoint \in justifiedCheckpoints
+       /\ LET validatorsWhoCastFinalizingVote == { 
+            v \in VALIDATORS: \E finalizingVote \in viewVotes:
+                /\ finalizingVote.validator = v
+                /\ LET ffgVote == finalizingVote.ffg_vote IN
+                    \* L14:
+                    /\ ffgVote.source = checkpoint
+                    \* L15:
+                    /\ ffgVote.target[2] = checkpoint[2] + 1 }
+        IN 3 * Cardinality(validatorsWhoCastFinalizingVote) >= 2 * N
+
+SlashableNodes ==
+    LET slashable_votes == { vote1 \in votes: \E vote2 \in votes:
+        \* equivocation
+        \/ /\ vote1.validator = vote2.validator
+           /\ vote1 /= vote2
+           /\ vote1.ffg_vote.target[2] = vote2.ffg_vote.target[2]
+        \* surround voting
+        \/ /\ vote1.validator = vote2.validator
+           /\ \/ vote1.ffg_vote.source[2] < vote2.ffg_vote.source[2]
+              \/ /\ vote1.ffg_vote.source[2] = vote2.ffg_vote.source[2]
+                 /\ vote1.ffg_vote.source[1].slot < vote2.ffg_vote.source[1].slot
+           /\ vote2.ffg_vote.target[2] < vote1.ffg_vote.target[2]
+    } IN { v.validator: v \in slashable_votes }
+
+\* Append a block to both chains (if `~forked`), or either `chain1` or `chain2` (if `forked`).
+\* @type: (Int, Str) => Bool;
+ProposeBlock(slot, body) ==
+    LET new_block == Block(slot, body) IN
+    /\ new_block \notin blocks
+    /\ blocks' = blocks \union { new_block }
+    /\ IF ~forked THEN
+        LET tip == chain1[chain1_tip_index] IN
+        LET extended_chain == chain1 @@ [ i \in {chain1_tip_index + 1} |-> new_block ] IN
+        /\ slot > tip.slot
+        /\ chain1' = extended_chain
+        /\ chain2' = extended_chain
+        /\ chain1_tip_index' = chain1_tip_index + 1
+        /\ chain2_tip_index' = chain2_tip_index + 1
+        /\ forked' \in BOOLEAN  \* may fork at this point
+        /\ ancestors' = ancestors @@ [ b \in {new_block} |-> { new_block } \union ancestors[tip] ]
+       ELSE
+        \/ LET tip == chain1[chain1_tip_index] IN
+           /\ slot > tip.slot
+           /\ chain1' = chain1 @@ [ i \in {chain1_tip_index + 1} |-> new_block ]
+           /\ chain1_tip_index' = chain1_tip_index + 1
+           /\ ancestors' = ancestors @@ [ b \in {new_block} |-> { new_block } \union ancestors[tip] ]
+           /\ UNCHANGED <<chain2, chain2_tip_index, forked>>
+        \/ LET tip == chain2[chain2_tip_index] IN
+           /\ slot > tip.slot
+           /\ chain2' = chain2 @@ [ i \in {chain2_tip_index + 1} |-> new_block ]
+           /\ chain2_tip_index' = chain2_tip_index + 1
+           /\ ancestors' = ancestors @@ [ b \in {new_block} |-> { new_block } \union ancestors[tip] ]
+           /\ UNCHANGED <<chain1, chain1_tip_index, forked>>
+    /\ UNCHANGED <<ffg_votes, votes, justified_checkpoints>>
+
+\* @type: ($checkpoint, $checkpoint, Set(Str)) => Bool;
+CastVotes(source, target, validators) ==
+    LET ffgVote == [ source |-> source, target |-> target ] IN
+    /\ IsValidFFGVote(ffgVote)
+    /\ validators /= {}
+    /\ ffg_votes' = ffg_votes \union { ffgVote }
+    /\ votes' = votes \union { Vote(v, ffgVote): v \in validators }
+    /\ LET allCheckpoints == {Checkpoint(block, i): block \in blocks, i \in CheckpointSlots}
+       IN \E allJustifiedCheckpoints \in SUBSET allCheckpoints:
+        /\ justified_checkpoints' = allJustifiedCheckpoints
+        /\ \A c \in allJustifiedCheckpoints: IsJustified(c, votes', allJustifiedCheckpoints)
+        /\ \A c \in (allCheckpoints \ allJustifiedCheckpoints): ~IsJustified(c, votes', allJustifiedCheckpoints)
+    /\ UNCHANGED <<blocks, chain1, chain1_tip_index, chain2, chain2_tip_index, forked, ancestors>>
+
+
+ExistTwoConflictingBlocks == \A b1, b2 \in blocks: ~AreConflictingBlocks(b1, b2)
+ExistTwoFinalizedConflictingBlocks ==
+    LET disagreement == \E c1, c2 \in justified_checkpoints: 
+        /\ IsFinalized(c1, votes, justified_checkpoints)
+        /\ IsFinalized(c2, votes, justified_checkpoints)
+        /\ AreConflictingBlocks(c1[1], c2[1])
+    IN ~disagreement
+
+AccountableSafety ==
+    LET disagreement == \E c1, c2 \in justified_checkpoints: 
+            /\ IsFinalized(c1, votes, justified_checkpoints)
+            /\ IsFinalized(c2, votes, justified_checkpoints)
+            /\ AreConflictingBlocks(c1[1], c2[1])
+    IN ~disagreement \/ Cardinality(SlashableNodes) * 3 >= N
+
+Init == 
+    /\ blocks = { GenesisBlock }
+    /\ forked \in BOOLEAN
+    /\ chain1_tip_index = 0
+    /\ chain2_tip_index = 0
+    /\ chain1 = [i \in {0} |-> GenesisBlock]
+    /\ chain2 = [i \in {0} |-> GenesisBlock]
+    /\ ancestors = [b \in {GenesisBlock} |-> { GenesisBlock }]
+    /\ ffg_votes = {}
+    /\ votes = {}
+    /\ justified_checkpoints = { GenesisCheckpoint }
+
+Next == 
+    \/ \E slot \in BlockSlots, body \in BLOCK_BODIES: ProposeBlock(slot, body)
+    \/ \E sourceBlock, targetBlock \in blocks, srcSlot, tgtSlot \in CheckpointSlots, validators \in SUBSET VALIDATORS: 
+        CastVotes(
+            Checkpoint(sourceBlock, srcSlot), 
+            Checkpoint(targetBlock, tgtSlot),
+            validators
+        )
+
+=============================================================================

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -250,11 +250,15 @@ CastVotes(source, target, validators) ==
     /\ validators /= {}
     /\ ffg_votes' = ffg_votes \union { ffgVote }
     /\ votes' = votes \union { Vote(v, ffgVote): v \in validators }
-    /\ LET allCheckpoints == { Checkpoint(block, i): block \in all_blocks, i \in CheckpointSlots } IN
-       \E allJustifiedCheckpoints \in SUBSET allCheckpoints:
+    /\ LET allCheckpoints == { Checkpoint(block, i): block \in all_blocks, i \in CheckpointSlots }
+           validCheckpoints == { c \in allCheckpoints: IsValidCheckpoint(c) }
+       IN
+       \E allJustifiedCheckpoints \in SUBSET validCheckpoints:
         /\ justified_checkpoints' = allJustifiedCheckpoints
-        /\ \A c \in allJustifiedCheckpoints: IsJustified(c, votes', allJustifiedCheckpoints)
-        /\ \A c \in (allCheckpoints \ allJustifiedCheckpoints): ~IsJustified(c, votes', allJustifiedCheckpoints)
+        /\ \A c \in allJustifiedCheckpoints:
+            IsJustified(c, votes', allJustifiedCheckpoints)
+        /\ \A c \in (allCheckpoints \ allJustifiedCheckpoints):
+            ~IsJustified(c, votes', allJustifiedCheckpoints)
     \*/\ justified_checkpoints' = JustifiedCheckpoints(votes')
     /\ UNCHANGED <<all_blocks, chain1, chain1_tip, chain2, chain2_tip, chain2_fork_block_number>>
 

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -85,9 +85,13 @@ NextBody(b, path) ==
 \* @type: ($block, $block) => Bool;
 IsLeftAncestorOfRight(before, after) ==
    /\ before.slot <= after.slot
+   /\ \/ before \in chain1 /\ after \in chain1
+      \/ before \in chain2 /\ after \in chain2
+   (*
    /\ \/ before.body >= 0 /\ after.body >= 0 /\ before.body <= after.body
       \/ before.body < 0 /\ after.body < 0 /\ -before.body <= -after.body
       \/ before.body >= 0 /\ after.body < 0 /\ before.body <= -after.body /\ after.body <= chain2_fork_block_number
+    *)
 
 \* @type: ($block, $block) => Bool;
 AreConflictingBlocks(b1, b2) ==

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -115,9 +115,15 @@ IsValidFFGVote(vote) ==
     /\ IsValidCheckpoint(vote.target)
     /\ vote.source[2] < vote.target[2]
     /\ IsLeftAncestorOfRight(vote.source[1], vote.target[1])
+    (* See ../spec/ffg.tla:
+    /\ has_block_hash(vote.message.ffg_source.block_hash, node_state)
+    /\ get_block_from_hash(vote.message.ffg_source.block_hash, node_state).slot = vote.message.ffg_source.block_slot
+    /\ has_block_hash(vote.message.ffg_target.block_hash, node_state)
+    /\ get_block_from_hash(vote.message.ffg_target.block_hash, node_state).slot = vote.message.ffg_target.block_slot
+     *)
     \* similar to has_block_hash
-    /\ \E b \in all_blocks: vote.source[1].body = b.body
-    /\ \E b \in all_blocks: vote.target[1].body = b.body
+    /\ vote.source[1] \in all_blocks
+    /\ vote.target[1] \in all_blocks
 
 \* @type: ($checkpoint, Set($vote), Set($checkpoint)) => Bool;
 IsJustified(checkpoint, viewVotes, fixpoint) == 

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -21,7 +21,10 @@ CONSTANT
     VALIDATORS,
     \* N = Cardinality(VALIDATORS)
     \* @type: Int;
-    N
+    N,
+    \* One third of the validators, N = 3 * T + 1
+    \* @type: Int;
+    T
 
 BlockSlots == 0..MAX_BLOCK_SLOT
 CheckpointSlots == 0..(MAX_BLOCK_SLOT+2)
@@ -147,7 +150,7 @@ IsJustified(checkpoint, viewVotes, fixpoint) ==
                 /\ IsLeftAncestorOfRight(ffgVote.source[1], checkpoint[1])
                 \* L8:
                 /\ ffgVote.target[2] = checkpoint[2] }    
-        IN 3 * Cardinality(validatorsWhoCastJustifyingVote) >= 2 * N
+        IN Cardinality(validatorsWhoCastJustifyingVote) >= 2 * T + 1
 
 \* @type: ($checkpoint, Set($vote), Set($checkpoint)) => Bool;
 IsFinalized(checkpoint, viewVotes, justifiedCheckpoints) ==
@@ -161,7 +164,7 @@ IsFinalized(checkpoint, viewVotes, justifiedCheckpoints) ==
                     /\ ffgVote.source = checkpoint
                     \* L15:
                     /\ ffgVote.target[2] = checkpoint[2] + 1 }
-        IN 3 * Cardinality(validatorsWhoCastFinalizingVote) >= 2 * N
+        IN Cardinality(validatorsWhoCastFinalizingVote) >= 2 * T + 1
 
 SlashableNodesOld ==
     LET slashable_votes == { vote1 \in votes: \E vote2 \in votes:
@@ -270,7 +273,7 @@ ExistTwoFinalizedConflictingBlocks ==
     IN ~disagreement
 
 AccountableSafety ==
-    \/ SlashableNodesOver(LAMBDA k: 3 * k >= N) \*Cardinality(SlashableNodes) * 3 >= N
+    \/ SlashableNodesOver(LAMBDA k: k >= T + 1) \*Cardinality(SlashableNodes) * 3 >= N
     \/ \A c1, c2 \in justified_checkpoints:
         \/ ~IsFinalized(c1, votes, justified_checkpoints)
         \/ ~IsFinalized(c2, votes, justified_checkpoints)

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -87,7 +87,7 @@ IsLeftAncestorOfRight(before, after) ==
    /\ before.slot <= after.slot
    /\ \/ before.body >= 0 /\ after.body >= 0 /\ before.body <= after.body
       \/ before.body < 0 /\ after.body < 0 /\ -before.body <= -after.body
-      \/ before.body >= 0 /\ after.body < 0 /\ before.body <= -after.body /\ chain2_fork_block_number <= after.body
+      \/ before.body >= 0 /\ after.body < 0 /\ before.body <= -after.body /\ after.body <= chain2_fork_block_number
 
 \* @type: ($block, $block) => Bool;
 AreConflictingBlocks(b1, b2) ==

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -20,7 +20,7 @@ CONSTANT
     \* @type: Int;
     N
 
-all_blockslots == 0..MAX_BLOCK_SLOT
+BlockSlots == 0..MAX_BLOCK_SLOT
 CheckpointSlots == 0..(MAX_BLOCK_SLOT+2)
 
 VARIABLES
@@ -67,7 +67,7 @@ IsLeftAncestorOfRight(before, after) ==
       \/ IsOnChain2(before) /\ IsOnChain2(after)
 
 \* @type: ($block, $block) => Bool;
-AreConflictingall_blocks(b1, b2) ==
+AreConflictingBlocks(b1, b2) ==
     LET b1_on_chain1 == IsOnChain1(b1)
         b1_on_chain2 == IsOnChain2(b1)
         b2_on_chain1 == IsOnChain1(b2)
@@ -79,7 +79,7 @@ AreConflictingall_blocks(b1, b2) ==
 \* @type: ($block) => Bool;
 IsValidBlock(block) ==
     /\ block.body \in (BLOCK_BODIES \union {GenesisBlockBody})
-    /\ block.slot \in all_blockslots
+    /\ block.slot \in BlockSlots
 
 \* @type: ($checkpoint) => Bool;
 IsValidCheckpoint(checkpoint) == 
@@ -177,19 +177,19 @@ CastVotes(source, target, validators) ==
         /\ \A c \in (allCheckpoints \ allJustifiedCheckpoints): ~IsJustified(c, votes', allJustifiedCheckpoints)
     /\ UNCHANGED <<all_blocks, chain1, chain1_tip_slot, chain2, chain2_tip_slot>>
 
-ExistTwoConflictingBlocks == \A b1, b2 \in all_blocks: ~AreConflictingall_blocks(b1, b2)
+ExistTwoConflictingBlocks == \A b1, b2 \in all_blocks: ~AreConflictingBlocks(b1, b2)
 ExistTwoFinalizedConflictingBlocks ==
     LET disagreement == \E c1, c2 \in justified_checkpoints: 
         /\ IsFinalized(c1, votes, justified_checkpoints)
         /\ IsFinalized(c2, votes, justified_checkpoints)
-        /\ AreConflictingall_blocks(c1[1], c2[1])
+        /\ AreConflictingBlocks(c1[1], c2[1])
     IN ~disagreement
 
 AccountableSafety ==
     LET disagreement == \E c1, c2 \in justified_checkpoints: 
             /\ IsFinalized(c1, votes, justified_checkpoints)
             /\ IsFinalized(c2, votes, justified_checkpoints)
-            /\ AreConflictingall_blocks(c1[1], c2[1])
+            /\ AreConflictingBlocks(c1[1], c2[1])
     IN ~disagreement \/ Cardinality(SlashableNodes) * 3 >= N
 
 Init == 
@@ -203,7 +203,7 @@ Init ==
     /\ justified_checkpoints = { GenesisCheckpoint }
 
 Next == 
-    \/ \E slot \in all_blockslots, body \in BLOCK_BODIES:
+    \/ \E slot \in BlockSlots, body \in BLOCK_BODIES:
         \/ ProposeBlockOnChain1(slot, body)
         \/ ProposeBlockOnChain2(slot, body)
     \/ \E sourceBlock, targetBlock \in all_blocks, srcSlot, tgtSlot \in CheckpointSlots, validators \in SUBSET VALIDATORS: 

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -228,7 +228,7 @@ Init ==
     /\ chain2 = { GenesisBlock }
     /\ chain1_next_idx = 2
     /\ chain2_next_idx = 2
-    /\ chain2_forked \in BOOLEAN
+    /\ chain2_forked = FALSE
     /\ ffg_votes = {}
     /\ votes = {}
     /\ justified_checkpoints = { GenesisCheckpoint }

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -213,7 +213,12 @@ CastVotes(source, target, validators) ==
     /\ validators /= {}
     /\ ffg_votes' = ffg_votes \union { ffgVote }
     /\ votes' = votes \union { Vote(v, ffgVote): v \in validators }
-    /\ justified_checkpoints' = JustifiedCheckpoints(votes')
+    /\ LET allCheckpoints == {Checkpoint(block, i): block \in all_blocks, i \in CheckpointSlots}
+       IN \E allJustifiedCheckpoints \in SUBSET allCheckpoints:
+        /\ justified_checkpoints' = allJustifiedCheckpoints
+        /\ \A c \in allJustifiedCheckpoints: IsJustified(c, votes', allJustifiedCheckpoints)
+        /\ \A c \in (allCheckpoints \ allJustifiedCheckpoints): ~IsJustified(c, votes', allJustifiedCheckpoints)
+    \*/\ justified_checkpoints' = JustifiedCheckpoints(votes')
     /\ UNCHANGED <<all_blocks, chain1, chain1_tip, chain2, chain2_tip, chain2_fork_block_number>>
 
 ExistTwoConflictingBlocks == \A b1, b2 \in all_blocks: ~AreConflictingBlocks(b1, b2)

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -87,6 +87,7 @@ IsLeftAncestorOfRight(before, after) ==
    /\ before.slot <= after.slot
    /\ \/ before.body >= 0 /\ after.body >= 0 /\ before.body <= after.body
       \/ before.body < 0 /\ after.body < 0 /\ -before.body <= -after.body
+      \/ before.body >= 0 /\ after.body < 0 /\ before.body <= -after.body /\ chain2_fork_block_number <= after.body
 
 \* @type: ($block, $block) => Bool;
 AreConflictingBlocks(b1, b2) ==

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -115,6 +115,9 @@ IsValidFFGVote(vote) ==
     /\ IsValidCheckpoint(vote.target)
     /\ vote.source[2] < vote.target[2]
     /\ IsLeftAncestorOfRight(vote.source[1], vote.target[1])
+    \* similar to has_block_hash
+    /\ vote.source \in all_blocks
+    /\ vote.target \in all_blocks
 
 \* @type: ($checkpoint, Set($vote), Set($checkpoint)) => Bool;
 IsJustified(checkpoint, viewVotes, fixpoint) == 

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -73,8 +73,8 @@ AreConflictingBlocks(b1, b2) ==
         b2_on_chain1 == IsOnChain1(b2)
         b2_on_chain2 == IsOnChain2(b2)
     IN
-    \/ b1_on_chain1 /\ ~b1_on_chain2 /\ b2_on_chain2
-    \/ b1_on_chain2 /\ ~b1_on_chain1 /\ b2_on_chain1
+    \/ b1_on_chain1 /\ ~b1_on_chain2 /\ b2_on_chain2 /\ ~b2_on_chain1
+    \/ b1_on_chain2 /\ ~b1_on_chain1 /\ b2_on_chain1 /\ ~b2_on_chain2
 
 \* @type: ($block) => Bool;
 IsValidBlock(block) ==

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -42,7 +42,7 @@ VARIABLES
     \* the latest block on chain 2
     \* @type: $block;
     chain2_tip,
-    \* If chain2_fork_block_number is not -1,
+    \* If chain2_fork_block_number is not equal to 0,
     \* then chain2 is a fork of chain1 starting at chain2_fork_block_number
     \* @type: Int;
     chain2_fork_block_number,
@@ -71,7 +71,7 @@ IsOnMainPath(b) == b.body >= 0
 IsOnForkPath(b) == b.body < 0
 
 \* Has chain2 forked from chain1?
-IsForked == chain2_fork_block_number /= -1
+IsForked == chain2_fork_block_number /= 0
 
 \* Compute the next body for a block and a path "main" or "fork".
 \* @type: ($block, Str) => $body;
@@ -182,7 +182,7 @@ ProposeBlockOnChain2(slot) ==
     /\ IsValidBlock(new_block)
     /\ slot > chain2_tip.slot
     /\ chain2_fork_block_number' =
-        IF IsForked THEN chain2_fork_block_number ELSE -new_block.body
+        IF IsForked THEN chain2_fork_block_number ELSE new_block.body
     /\ all_blocks' = all_blocks \union { new_block }
     /\ chain2' = chain2 \union { new_block }
     /\ chain2_tip' = new_block
@@ -227,7 +227,7 @@ Init ==
     /\ chain2_tip = [ slot |-> 0, body |-> 0 ]
     /\ chain1 = { GenesisBlock }
     /\ chain2 = { GenesisBlock }
-    /\ chain2_fork_block_number = -1
+    /\ chain2_fork_block_number = 0
     /\ ffg_votes = {}
     /\ votes = {}
     /\ justified_checkpoints = { GenesisCheckpoint }

--- a/spec-abstract-noclosure/ffg.tla
+++ b/spec-abstract-noclosure/ffg.tla
@@ -187,11 +187,11 @@ ProposeBlockOnChain2(slot) ==
     /\ chain2_next_idx' = chain2_next_idx + 1
     /\ UNCHANGED <<chain1, chain1_tip_slot, chain1_next_idx, ffg_votes, votes, justified_checkpoints>>
 
-JustifiedCheckpoints ==
+JustifiedCheckpoints(viewVotes) ==
     \* @type: Set($checkpoint) => Set($checkpoint);
     LET AccJustified(justifiedSoFar, justifiedCheckpointSlot) ==
         LET candidateCheckpoints == { Checkpoint(block, justifiedCheckpointSlot): block \in all_blocks } IN
-        LET newJustifiedCheckpoints == { c \in candidateCheckpoints: IsJustified(c, votes, justifiedSoFar) } IN
+        LET newJustifiedCheckpoints == { c \in candidateCheckpoints: IsJustified(c, viewVotes, justifiedSoFar) } IN
         justifiedSoFar \union newJustifiedCheckpoints
     IN ApaFoldSeqLeft(AccJustified, { GenesisCheckpoint }, MkSeq(MAX_BLOCK_SLOT+2, (* @type: Int => Int; *) LAMBDA i: i))
 
@@ -202,7 +202,7 @@ CastVotes(source, target, validators) ==
     /\ validators /= {}
     /\ ffg_votes' = ffg_votes \union { ffgVote }
     /\ votes' = votes \union { Vote(v, ffgVote): v \in validators }
-    /\ justified_checkpoints' = JustifiedCheckpoints
+    /\ justified_checkpoints' = JustifiedCheckpoints(votes')
     /\ UNCHANGED <<all_blocks, chain1, chain1_tip_slot, chain2, chain2_tip_slot, chain1_next_idx, chain2_next_idx, chain2_forked>>
 
 ExistTwoConflictingBlocks == \A b1, b2 \in all_blocks: ~AreConflictingBlocks(b1, b2)

--- a/spec-abstract-noclosure/ffg_inductive.tla
+++ b/spec-abstract-noclosure/ffg_inductive.tla
@@ -1,48 +1,10 @@
------------------------------ MODULE MC_ffg -----------------------------
+---------------------------- MODULE ffg_inductive -----------------------------
+(**
+ * An inductive invariant for the FFG module.
+ *)
+EXTENDS ffg
 
-EXTENDS FiniteSets
-
-\* @type: Int;
-MAX_BLOCK_SLOT == 5
-\* @type: Int;
-MAX_BLOCK_BODY == 3
-
-\* @type: Set(Str);
-VALIDATORS == {"V1", "V2", "V3", "V4"}
-
-N == 4
-
-VARIABLES
-    \* the set of all_blocks
-    \* @type: Set($block);
-    all_blocks,
-    \* the set of blocks on chain 1
-    \* @type: Set($block);
-    chain1,
-    \* the latest block on chain 1
-    \* @type: $block;
-    chain1_tip,
-    \* the set of blocks on chain 2
-    \* @type: Set($block);
-    chain2,
-    \* the latest block on chain 2
-    \* @type: $block;
-    chain2_tip,
-    \* If chain2_fork_block_number is not equal to 0,
-    \* then chain2 is a fork of chain1 starting at chain2_fork_block_number
-    \* @type: Int;
-    chain2_fork_block_number,
-    \* @type: Set($ffgVote);
-    ffg_votes,
-    \* @type: Set($vote);
-    votes,
-    \* @type: Set($checkpoint);
-    justified_checkpoints
-
-
-INSTANCE ffg
-
-Abs(x) == IF x >= 0 THEN x ELSE -x
+LOCAL Abs(x) == IF x >= 0 THEN x ELSE -x
 
 IndInv ==
     /\ -MAX_BLOCK_BODY <= chain2_fork_block_number /\ chain2_fork_block_number <= 0
@@ -88,18 +50,4 @@ IndInv ==
         /\ \A c \in (allCheckpoints \ allJustifiedCheckpoints): ~IsJustified(c, votes', allJustifiedCheckpoints)
     \*/\ justified_checkpoints = JustifiedCheckpoints(votes)
 
-IndInit ==
-    \* We choose two different bounds for creating chain1 and chain2 with Gen.
-    \* See Apalache issue #2973.
-    /\ chain1 = Gen(3)
-    /\ chain1_tip \in chain1
-    /\ chain2 = Gen(4)
-    /\ chain2_tip \in chain2
-    /\ ffg_votes = Gen(5) \* must be >= 4 to observe disagreement
-    /\ votes = Gen(12)    \* must be >= 12 to observe disagreement
-    /\ \E fork_number \in Int:
-        /\ fork_number \in -MAX_BLOCK_BODY..0
-        /\ chain2_fork_block_number = fork_number
-    /\ IndInv
-
-=============================================================================
+===============================================================================

--- a/spec-abstract-noclosure/ffg_inductive.tla
+++ b/spec-abstract-noclosure/ffg_inductive.tla
@@ -43,12 +43,12 @@ IndInv ==
     /\ \A vote \in votes:
         /\ vote.ffg_vote \in ffg_votes
         /\ vote.validator \in VALIDATORS
+	/\ GenesisCheckpoint \in checkpoints
+    /\ GenesisCheckpoint \in checkpoints
     /\ \A c \in checkpoints: IsValidCheckpoint(c)
-    /\ justified_checkpoints = JustifiedCheckpoints(votes)
-    (*/\ \E allJustifiedCheckpoints \in SUBSET checkpoints:
-        /\ justified_checkpoints' = allJustifiedCheckpoints
-        /\ \A c \in allJustifiedCheckpoints: IsJustified(c, votes', allJustifiedCheckpoints)
-        /\ \A c \in (allCheckpoints \ allJustifiedCheckpoints): ~IsJustified(c, votes', allJustifiedCheckpoints)
-     *)
+    \*/\ justified_checkpoints = JustifiedCheckpoints(votes)
+    /\ GenesisCheckpoint \in justified_checkpoints
+    /\ \A c \in justified_checkpoints: IsJustified(c, votes, justified_checkpoints)
+    /\ \A c \in (checkpoints \ justified_checkpoints): ~IsJustified(c, votes, justified_checkpoints)
 
 ===============================================================================

--- a/spec-abstract-noclosure/ffg_inductive.tla
+++ b/spec-abstract-noclosure/ffg_inductive.tla
@@ -43,11 +43,12 @@ IndInv ==
     /\ \A vote \in votes:
         /\ vote.ffg_vote \in ffg_votes
         /\ vote.validator \in VALIDATORS
-    /\ LET allCheckpoints == {Checkpoint(block, i): block \in all_blocks, i \in CheckpointSlots}
-       IN \E allJustifiedCheckpoints \in SUBSET allCheckpoints:
+    /\ \A c \in checkpoints: IsValidCheckpoint(c)
+    /\ justified_checkpoints = JustifiedCheckpoints(votes)
+    (*/\ \E allJustifiedCheckpoints \in SUBSET checkpoints:
         /\ justified_checkpoints' = allJustifiedCheckpoints
         /\ \A c \in allJustifiedCheckpoints: IsJustified(c, votes', allJustifiedCheckpoints)
         /\ \A c \in (allCheckpoints \ allJustifiedCheckpoints): ~IsJustified(c, votes', allJustifiedCheckpoints)
-    \*/\ justified_checkpoints = JustifiedCheckpoints(votes)
+     *)
 
 ===============================================================================

--- a/spec-abstract-noclosure/ffg_inductive.tla
+++ b/spec-abstract-noclosure/ffg_inductive.tla
@@ -43,12 +43,11 @@ IndInv ==
     /\ \A vote \in votes:
         /\ vote.ffg_vote \in ffg_votes
         /\ vote.validator \in VALIDATORS
-	/\ GenesisCheckpoint \in checkpoints
-    /\ GenesisCheckpoint \in checkpoints
-    /\ \A c \in checkpoints: IsValidCheckpoint(c)
     \*/\ justified_checkpoints = JustifiedCheckpoints(votes)
     /\ GenesisCheckpoint \in justified_checkpoints
     /\ \A c \in justified_checkpoints: IsJustified(c, votes, justified_checkpoints)
-    /\ \A c \in (checkpoints \ justified_checkpoints): ~IsJustified(c, votes, justified_checkpoints)
+    /\ LET allCheckpoints == {Checkpoint(block, i): block \in all_blocks, i \in CheckpointSlots} IN
+       \A c \in (allCheckpoints \ justified_checkpoints):
+         ~IsJustified(c, votes, justified_checkpoints)
 
 ===============================================================================

--- a/spec-abstract-noclosure/typedefs.tla
+++ b/spec-abstract-noclosure/typedefs.tla
@@ -1,7 +1,7 @@
 ----------------------------- MODULE typedefs -----------------------------
 
 (*
-    @typeAlias: body = Str;
+    @typeAlias: body = Int;
     @typeAlias: block = {
         slot: Int,
         body: $body

--- a/spec-abstract-noclosure/typedefs.tla
+++ b/spec-abstract-noclosure/typedefs.tla
@@ -1,6 +1,12 @@
 ----------------------------- MODULE typedefs -----------------------------
 
 (*
+    We model two sequences of block bodies:
+
+    0 -> +1 -> +2 -> +3 -> +4 -> +5
+             \     \     \     \
+         -1 -> -2 -> -3 -> -4 -> -5
+
     @typeAlias: body = Int;
     @typeAlias: block = {
         slot: Int,

--- a/spec-abstract-noclosure/typedefs.tla
+++ b/spec-abstract-noclosure/typedefs.tla
@@ -1,0 +1,20 @@
+----------------------------- MODULE typedefs -----------------------------
+
+(*
+    @typeAlias: block = {
+        slot: Int,
+        body: Str
+    };
+    @typeAlias: checkpoint = <<$block, Int>>;
+    @typeAlias: ffgVote = {
+        source: $checkpoint,
+        target: $checkpoint
+    };
+    @typeAlias: vote = {
+        validator: Str,
+        ffg_vote: $ffgVote
+    };
+*)
+TYPEDEFS == TRUE
+
+=============================================================================

--- a/spec-abstract-noclosure/typedefs.tla
+++ b/spec-abstract-noclosure/typedefs.tla
@@ -1,9 +1,10 @@
 ----------------------------- MODULE typedefs -----------------------------
 
 (*
+    @typeAlias: body = Str;
     @typeAlias: block = {
         slot: Int,
-        body: Str
+        body: $body
     };
     @typeAlias: checkpoint = <<$block, Int>>;
     @typeAlias: ffgVote = {


### PR DESCRIPTION
Opening a PR for the sake of reviewing it. We have been working in multiple branches on it over this week. The current version incorporates pretty much all of the ideas about making the specification amenable for inductive invariant checking. The status of the experiments:

 - [x] $Init => IndInv$ in <1min
 - [ ] $IndInit => AccountableSafety$ is still being checked
 - [x] counterexamples found to $ExistTwoConflictingBlocks$ and $ExistTwoFinalizedConflictingBlocks$
 - [x] $IndInit \land Next => IndInv'$ is checked in < 2 min (in parallel)