### PR TITLE
move the translation rules to the appendix

### DIFF
--- a/reports/report.tex
+++ b/reports/report.tex
@@ -51,12 +51,21 @@
 \input{spec3-alloy}
 \input{spec4}
 
+\bibliographystyle{plain}
+\bibliography{ref}
+
+% appendix
+\pagebreak
+
+\appendix
+
+The work done in this section is the main contribution of Milestone~3.  Since
+this section is quite long and technical, we have decided to add it in the
+appendix.
+
 % Milestone 3 - Translation rules
 \input{rules}
 
 \input{recursion-proofs}
-
-\bibliographystyle{plain}
-\bibliography{ref}
 
 \end{document}

--- a/reports/rules.tex
+++ b/reports/rules.tex
@@ -1,6 +1,6 @@
 %! TeX root = report.tex
 
-\section{M3: Translating Python specifications to \tlap{}}\label{section3}
+\section{Translating Python specifications to \tlap{}}\label{section3}
 
 In this section, we present our results on translating a subset of Python that
 is used to write executable specifications in the projects such as
@@ -43,6 +43,6 @@ notation:
 The translation rules can be easily adapted to~$\Seq(\htau)$ instead
 of~$\List(\htau)$.
 
-\include{pyToTla}
+\input{pyToTla}
 
-\include{meta}
+\input{meta}


### PR DESCRIPTION
This PR reorganizes the report a bit. The translation rules and the detailed proofs are moved to the appendix.